### PR TITLE
Respect YGOPRO_*_PATH

### DIFF
--- a/gframe/Base64.h
+++ b/gframe/Base64.h
@@ -8,7 +8,7 @@
    More information at
 	 https://renenyffenegger.ch/notes/development/Base64/Encoding-and-decoding-base-64-with-cpp
    Version: 2.rc.04 (release candidate)
-   Copyright (C) 2004-2017, 2020 René Nyffenegger
+   Copyright (C) 2004-2017, 2020 RenÃ© Nyffenegger
    Copyright (C) 2021 Edoardo Lolletti
    This source code is provided 'as-is', without any express or implied
    warranty. In no event will the author be held liable for any damages
@@ -23,7 +23,7 @@
    2. Altered source versions must be plainly marked as such, and must not be
 	  misrepresented as being the original source code.
    3. This notice may not be removed or altered from any source distribution.
-   René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+   RenÃ© Nyffenegger rene.nyffenegger@adp-gmbh.ch
 */
 #ifndef BASE64_H
 #define BASE64_H

--- a/gframe/data_handler.cpp
+++ b/gframe/data_handler.cpp
@@ -17,13 +17,28 @@
 #include "Android/COSAndroidOperator.h"
 #include "Android/porting_android.h"
 #endif
+#include "deck_manager.h"
 
 namespace ygo {
 
 void DataHandler::LoadDatabases() {
-	if(Utils::FileExists(EPRO_TEXT("./cards.cdb"))) {
-		if(dataManager->LoadDB(EPRO_TEXT("./cards.cdb")))
-			WindBot::AddDatabase(EPRO_TEXT("./cards.cdb"));
+#ifdef YGOPRO_ENVIRONMENT_PATHS
+	const char* data_path_env = getenv("YGOPRO_DATA_PATH");
+	if(!data_path_env) return;
+	epro::path_string data_path_s = Utils::ToPathString(data_path_env);
+	ygo::Utils::PathForeach(
+		data_path_s,
+		[&](const epro::path_string& prefix) {
+			for (auto& file : Utils::FindFiles(prefix, { EPRO_TEXT("cdb") }))
+				if(dataManager->LoadDB(prefix / file))
+					WindBot::AddDatabase(prefix / file);
+			deckManager->LoadLFListSingle(prefix / EPRO_TEXT("lflist.conf"));
+			dataManager->LoadStrings(prefix / EPRO_TEXT("strings.conf"));
+		});
+#else
+	if(Utils::FileExists(EPRO_TEXT("cards.cdb"))) {
+		if(dataManager->LoadDB(EPRO_TEXT("cards.cdb")))
+			WindBot::AddDatabase(EPRO_TEXT("cards.cdb"));
 	}
 	for(auto& file : Utils::FindFiles(EPRO_TEXT("./expansions/"), { EPRO_TEXT("cdb") }, 2)) {
 		epro::path_string db = EPRO_TEXT("./expansions/") + file;
@@ -31,6 +46,7 @@ void DataHandler::LoadDatabases() {
 			WindBot::AddDatabase(db);
 	}
 	LoadArchivesDB();
+#endif
 }
 void DataHandler::LoadArchivesDB() {
 	for(auto& archive : Utils::archives) {

--- a/gframe/data_handler.cpp
+++ b/gframe/data_handler.cpp
@@ -142,7 +142,7 @@ DataHandler::DataHandler(epro::path_stringview working_dir) {
 	LoadZipArchives();
 	deckManager = std::unique_ptr<DeckManager>(new DeckManager());
 	gitManager = std::unique_ptr<RepoManager>(new RepoManager());
-	sounds = std::unique_ptr<SoundManager>(new SoundManager(configs->soundVolume / 100.0, configs->musicVolume / 100.0, configs->enablesound, configs->enablemusic, Utils::working_dir));
+	sounds = std::unique_ptr<SoundManager>(new SoundManager(configs->soundVolume / 100.0, configs->musicVolume / 100.0, configs->enablesound, configs->enablemusic, configs->data_directory));
 	gitManager->LoadRepositoriesFromJson(configs->user_configs);
 	gitManager->LoadRepositoriesFromJson(configs->configs);
 	if(gitManager->TerminateIfNothingLoaded())

--- a/gframe/data_handler.cpp
+++ b/gframe/data_handler.cpp
@@ -132,8 +132,9 @@ DataHandler::DataHandler(epro::path_stringview working_dir) {
 #endif
 	filesystem = new irr::io::CFileSystem();
 	dataManager = std::unique_ptr<DataManager>(new DataManager());
-	auto strings_loaded = dataManager->LoadStrings(EPRO_TEXT("./config/strings.conf"));
-	strings_loaded = dataManager->LoadStrings(EPRO_TEXT("./expansions/strings.conf")) || strings_loaded;
+	auto strings_loaded = dataManager->LoadStrings(configs->config_directory / EPRO_TEXT("strings.conf"));
+	strings_loaded = strings_loaded || dataManager->LoadStrings(configs->sysconfig_directory / EPRO_TEXT("strings.conf"));
+	strings_loaded = dataManager->LoadStrings(configs->data_directory / EPRO_TEXT("expansions/strings.conf")) || strings_loaded;
 	if(!strings_loaded)
 		throw std::runtime_error("Failed to load strings!");
 	Utils::filesystem = filesystem;
@@ -150,8 +151,8 @@ DataHandler::DataHandler(epro::path_stringview working_dir) {
 	LoadDatabases();
 	LoadPicUrls();
 	deckManager->LoadLFList();
-	dataManager->LoadIdsMapping(EPRO_TEXT("./config/mappings.json"));
-	WindBotPanel::absolute_deck_path = Utils::ToUnicodeIfNeeded(Utils::GetAbsolutePath(EPRO_TEXT("./deck")));
+	dataManager->LoadIdsMapping(configs->config_directory / EPRO_TEXT("mappings.json"));
+	WindBotPanel::absolute_deck_path = Utils::ToUnicodeIfNeeded(configs->data_directory / EPRO_TEXT("./deck"));
 }
 DataHandler::~DataHandler() {
 	if(filesystem)

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -105,9 +105,11 @@ bool DeckManager::LoadLFListFolder(epro::path_stringview _path) {
 	return loaded;
 }
 void DeckManager::LoadLFList() {
+#ifndef YGOPRO_ENVIRONMENT_PATHS
 	LoadLFListSingle(EPRO_TEXT("./expansions/lflist.conf"));
 	LoadLFListSingle(EPRO_TEXT("./lflist.conf"));
 	LoadLFListFolder(EPRO_TEXT("./lflists/"));
+#endif
 	LFList nolimit;
 	nolimit.listName = L"N/A"; // N/A
 	nolimit.hash = 0;

--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -7,6 +7,9 @@
 #include "data_manager.h"
 #include "game.h"
 #include <IGUIEditBox.h>
+#include <iostream>
+#include <fstream>
+#include <fmt/format.h>
 #include "Base64.h"
 #include "utils.h"
 #include "client_card.h"
@@ -416,8 +419,8 @@ bool DeckManager::LoadDeck(epro::path_stringview file, Deck* deck, bool separate
 	cardlist_type mainlist;
 	cardlist_type sidelist;
 	cardlist_type extralist;
-	if(!LoadCardList(fmt::format(EPRO_TEXT("./deck/{}.ydk"), file), &mainlist, separated ? &extralist : nullptr, &sidelist)) {
-		if(!LoadCardList({ file.data(), file.size() }, &mainlist, separated ? &extralist : nullptr, &sidelist))
+	if(!LoadCardList(fmt::format(gGameConfig->data_directory / EPRO_TEXT("deck/{}.ydk"), file), &mainlist, separated ? &extralist : nullptr, &sidelist)) {
+		if(!LoadCardList({file.data(), file.size()}, &mainlist, separated ? &extralist : nullptr, &sidelist))
 			return false;
 	}
 	if(deck)
@@ -429,8 +432,8 @@ bool DeckManager::LoadDeck(epro::path_stringview file, Deck* deck, bool separate
 bool DeckManager::LoadDeckDouble(epro::path_stringview file, epro::path_stringview file2, Deck* deck) {
 	cardlist_type mainlist;
 	cardlist_type sidelist;
-	LoadCardList(fmt::format(EPRO_TEXT("./deck/{}.ydk"), file), &mainlist, nullptr, &sidelist);
-	LoadCardList(fmt::format(EPRO_TEXT("./deck/{}.ydk"), file2), &mainlist, nullptr, &sidelist);
+	LoadCardList(gGameConfig->data_directory / fmt::format(EPRO_TEXT("deck/{}.ydk"), file), &mainlist, nullptr, &sidelist);
+	LoadCardList(gGameConfig->data_directory / fmt::format(EPRO_TEXT("deck/{}.ydk"), file2), &mainlist, nullptr, &sidelist);
 	if(deck)
 		LoadDeck(*deck, mainlist, sidelist);
 	else
@@ -438,7 +441,7 @@ bool DeckManager::LoadDeckDouble(epro::path_stringview file, epro::path_stringvi
 	return true;
 }
 bool DeckManager::SaveDeck(Deck& deck, epro::path_stringview name) {
-	const auto fullname = fmt::format(EPRO_TEXT("./deck/{}.ydk"), name);
+	const auto fullname = gGameConfig->data_directory / fmt::format(EPRO_TEXT("./deck/{}.ydk"), name);
 #if defined(__MINGW32__) && defined(UNICODE)
 	auto fd = _wopen(fullname.data(), _O_WRONLY);
 	if(fd == -1)
@@ -462,7 +465,7 @@ bool DeckManager::SaveDeck(Deck& deck, epro::path_stringview name) {
 	return true;
 }
 bool DeckManager::SaveDeck(epro::path_stringview name, const cardlist_type& mainlist, const cardlist_type& extralist, const cardlist_type& sidelist) {
-	const auto fullname = fmt::format(EPRO_TEXT("./deck/{}.ydk"), name);
+	const auto fullname = gGameConfig->data_directory / fmt::format(EPRO_TEXT("./deck/{}.ydk"), name);
 #if defined(__MINGW32__) && defined(UNICODE)
 	auto fd = _wopen(fullname.data(), _O_WRONLY);
 	if(fd == -1)
@@ -613,9 +616,10 @@ bool DeckManager::ImportDeckBase64Omega(Deck& deck, epro::wstringview buffer) {
 	return true;
 }
 bool DeckManager::DeleteDeck(Deck& deck, epro::path_stringview name) {
-	return Utils::FileDelete(fmt::format(EPRO_TEXT("./deck/{}.ydk"), name));
+	return Utils::FileDelete(gGameConfig->data_directory / fmt::format(EPRO_TEXT("deck/{}.ydk"), name));
 }
 bool DeckManager::RenameDeck(epro::path_stringview oldname, epro::path_stringview newname) {
-	return Utils::FileMove(fmt::format(EPRO_TEXT("./deck/{}.ydk"), oldname), fmt::format(EPRO_TEXT("./deck/{}.ydk"), newname));
+	epro::path_string deck = gGameConfig->data_directory / EPRO_TEXT("deck");
+	return Utils::FileMove(deck / oldname + EPRO_TEXT(".ydk"), deck / newname + EPRO_TEXT(".ydk"));
 }
 }

--- a/gframe/deck_manager.h
+++ b/gframe/deck_manager.h
@@ -7,6 +7,7 @@
 #include "network.h"
 #include "text_types.h"
 #include "data_manager.h"
+#include "game_config.h"
 
 namespace ygo {
 

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -1991,7 +1991,7 @@ bool Game::ApplySkin(const epro::path_string& skinname, bool reload, bool firstr
 #include "custom_skin_enum.inl"
 #undef DECLR
 #undef CLR
-			imageManager.ChangeTextures(fmt::format(EPRO_TEXT("./skin/{}/textures/"), prev_skin));
+			imageManager.ChangeTextures(gGameConfig->data_directory / EPRO_TEXT("skin/") + prev_skin + EPRO_TEXT("/textures/"));
 		} else {
 			applied = false;
 			auto skin = env->createSkin(irr::gui::EGST_WINDOWS_METALLIC);

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -3469,6 +3469,31 @@ void Game::UpdateUnzipBar(unzip_payload* payload) {
 	game->updateProgressBottom->setProgress(payload->percentage);
 }
 void Game::PopulateResourcesDirectories() {
+#ifdef YGOPRO_ENVIRONMENT_PATHS
+	const char* script_path_env = getenv("YGOPRO_SCRIPT_PATH");
+	if (script_path_env)
+		Utils::PathForeach(
+			Utils::ToPathString(script_path_env),
+			[this](const epro::path_string& prefix) {
+				epro::path_string script_dir = Utils::NormalizePath(prefix);
+				script_dirs.push_back(script_dir);
+				auto script_subdirs = Utils::FindSubfolders(script_dir);
+				script_dirs.insert(script_dirs.end(), script_subdirs.begin(), script_subdirs.end());
+			});
+	const char* image_path_env = getenv("YGOPRO_IMAGE_PATH");
+	if(image_path_env)
+		Utils::PathForeach(
+			Utils::ToPathString(image_path_env),
+			[this](const epro::path_string& prefix) {
+				epro::path_string image_dir = Utils::NormalizePath(prefix);
+				pic_dirs.push_back(image_dir);
+				cover_dirs.push_back(image_dir / EPRO_TEXT("cover/"));
+				field_dirs.push_back(image_dir / EPRO_TEXT("field/"));
+			});
+	pic_dirs.push_back(EPRO_TEXT("./pics/"));
+	cover_dirs.push_back(EPRO_TEXT("./pics/cover/"));
+	field_dirs.push_back(EPRO_TEXT("./pics/field/"));
+#else
 	script_dirs.push_back(EPRO_TEXT("./expansions/script/"));
 	auto expansions_subdirs = Utils::FindSubfolders(EPRO_TEXT("./expansions/script/"));
 	script_dirs.insert(script_dirs.end(), std::make_move_iterator(expansions_subdirs.begin()), std::make_move_iterator(expansions_subdirs.end()));
@@ -3485,6 +3510,7 @@ void Game::PopulateResourcesDirectories() {
 	field_dirs.push_back(EPRO_TEXT("./expansions/pics/field/"));
 	field_dirs.push_back(EPRO_TEXT("archives"));
 	field_dirs.push_back(EPRO_TEXT("./pics/field/"));
+#endif
 }
 
 void Game::PopulateLocales() {

--- a/gframe/game_config.h
+++ b/gframe/game_config.h
@@ -17,7 +17,13 @@ struct GameConfig
 {
 	GameConfig();
 	bool Load(const epro::path_char* filename);
+	inline bool Load(const epro::path_string& path) {
+		return Load(path.c_str());
+	}
 	bool Save(const epro::path_char* filename);
+	inline bool Save(const epro::path_string& path) {
+		return Save(path.c_str());
+	}
 
 	irr::video::E_DRIVER_TYPE driver_type{ irr::video::EDT_COUNT };
 #if defined(__linux__) && !defined(__ANDROID__) && (IRRLICHT_VERSION_MAJOR==1 && IRRLICHT_VERSION_MINOR==9)
@@ -110,6 +116,13 @@ struct GameConfig
 	epro::path_string locale{ EPRO_TEXT("English") };
 	std::string ssl_certificate_path;
 	std::string override_ssl_certificate_path;
+
+	epro::path_string cache_directory = EPRO_TEXT("./");
+	epro::path_string config_directory = EPRO_TEXT("./config");
+	epro::path_string data_directory = EPRO_TEXT("./");
+
+	epro::path_string sysconfig_directory = EPRO_TEXT("./config");
+	epro::path_string sysdata_directory = EPRO_TEXT("./");
 
 	nlohmann::json configs;
 	nlohmann::json user_configs;

--- a/gframe/gframe.cpp
+++ b/gframe/gframe.cpp
@@ -185,7 +185,6 @@ int _tmain(int argc, epro::path_char* argv[]) {
 		ygo::gImageDownloader = data->imageDownloader.get();
 		ygo::gDataManager = data->dataManager.get();
 		ygo::gSoundManager = data->sounds.get();
-		ygo::gGameConfig = data->configs.get();
 		ygo::gRepoManager = data->gitManager.get();
 		ygo::gdeckManager = data->deckManager.get();
 	}

--- a/gframe/image_downloader.cpp
+++ b/gframe/image_downloader.cpp
@@ -123,28 +123,24 @@ void ImageDownloader::DownloadPic() {
 		auto& map_elem = downloading_images[type][code];
 		map_elem.status = downloadStatus::DOWNLOADING;
 		lck.unlock();
-		auto name = fmt::format(EPRO_TEXT("./pics/temp/{}"), code);
+		auto name = gGameConfig->cache_directory / fmt::format(EPRO_TEXT("pics/temp/{}"), code);
 		if(type == imgType::THUMB)
 			type = imgType::ART;
-		epro::path_stringview dest;
-		switch(type) {
-			case imgType::ART:
-			case imgType::THUMB: {
-				dest = EPRO_TEXT("./pics/{}"_sv);
-				break;
+		auto dest_folder = [type, &name, code]()->epro::path_string {
+			const epro::path_string code_s = fmt::format(EPRO_TEXT("{}"), code);
+			switch(type) {
+				default:
+				case imgType::ART:
+				case imgType::THUMB:
+					return gGameConfig->cache_directory / EPRO_TEXT("pics") / code_s;
+				case imgType::FIELD:
+					name.append(EPRO_TEXT("_f"));
+					return gGameConfig->cache_directory / EPRO_TEXT("pics/field") / code_s;
+				case imgType::COVER:
+					name.append(EPRO_TEXT("_c"));
+					return gGameConfig->cache_directory / EPRO_TEXT("pics/cover") / code_s;
 			}
-			case imgType::FIELD: {
-				dest = EPRO_TEXT("./pics/field/{}"_sv);
-				name.append(EPRO_TEXT("_f"));
-				break;
-			}
-			case imgType::COVER: {
-				dest = EPRO_TEXT("./pics/cover/{}"_sv);
-				name.append(EPRO_TEXT("_c"));
-				break;
-			}
-		}
-		auto dest_folder = fmt::format(to_string_view(dest), code);
+		}();
 		CURLcode res{ static_cast<CURLcode>(1) };
 		for(auto& src : pic_urls) {
 			if(src.type != type)

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -14,12 +14,12 @@
 
 static int constexpr IMAGES_LOAD_PER_FRAME_MAX = 50;
 
-#define BASE_PATH EPRO_TEXT("./textures/")
+#define BASE_PATH EPRO_TEXT("textures/")
 
 namespace ygo {
 
-#define X(x) (textures_path + EPRO_TEXT(x)).data()
-#define GET(obj,fun1,fun2) do {obj=fun1; if(!obj) obj=fun2; def_##obj=obj;}while(0)
+#define X(x) (textures_path / EPRO_TEXT(x)).c_str()
+#define GET(obj,fun1,fun2) obj=fun1; if(!obj) obj=fun2;
 #define GTFF(path,ext,w,h) GetTextureFromFile(X(path ext), mainGame->Scale(w), mainGame->Scale(h))
 #define GET_TEXTURE_SIZED(obj,path,w,h) GET(obj,GTFF(path,".png",w,h),GTFF(path,".jpg",w,h))
 #define GET_TEXTURE(obj,path) GET(obj,driver->getTexture(X(path ".png")),driver->getTexture(X(path ".jpg")))
@@ -52,7 +52,8 @@ ImageManager::~ImageManager() {
 }
 bool ImageManager::Initial() {
 	timestamp_id = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-	textures_path = BASE_PATH;
+	// TODO: Allow overriding through data_directory
+	textures_path = gGameConfig->sysdata_directory / BASE_PATH;
 	GET_TEXTURE_SIZED(tCover[0], "cover", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
 	CHECK_RETURN(tCover[0], "cover");
 	GET_TEXTURE_SIZED(tCover[1], "cover2", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);

--- a/gframe/image_manager.cpp
+++ b/gframe/image_manager.cpp
@@ -17,12 +17,46 @@ static int constexpr IMAGES_LOAD_PER_FRAME_MAX = 50;
 #define BASE_PATH EPRO_TEXT("textures/")
 
 namespace ygo {
+void ImageManager::InitTexture_(irr::video::ITexture*& texture, irr::video::ITexture*& default_texture, epro::path_string path)
+{
+	auto png = path + EPRO_TEXT(".png"), jpg = path + EPRO_TEXT(".jpg");
+	texture = driver->getTexture((textures_path / png).c_str());
+	if (!texture) texture = driver->getTexture((textures_path / jpg).c_str());
+	if (!texture) texture = driver->getTexture((textures_path2 / png).c_str());
+	if (!texture) texture = driver->getTexture((textures_path2 / jpg).c_str());
+	default_texture = texture;
+}
+void ImageManager::InitTextureSized_(irr::video::ITexture*& texture, irr::video::ITexture*& default_texture, epro::path_string path, uint32_t w, uint32_t h)
+{
+	auto png = path + EPRO_TEXT(".png"), jpg = path + EPRO_TEXT(".jpg");
+	texture = GetTextureFromFile((textures_path / png).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	if (!texture) texture = GetTextureFromFile((textures_path / jpg).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	if (!texture) texture = GetTextureFromFile((textures_path2 / png).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	if (!texture) texture = GetTextureFromFile((textures_path2 / jpg).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	default_texture = texture;
+}
+void ImageManager::GetTexture_(irr::video::ITexture*& texture, irr::video::ITexture* default_texture, epro::path_string path)
+{
+	auto png = path + EPRO_TEXT(".png"), jpg = path + EPRO_TEXT(".jpg");
+	texture = driver->getTexture((textures_path / png).c_str());
+	if (!texture) texture = driver->getTexture((textures_path / jpg).c_str());
+	if (!texture) texture = driver->getTexture((textures_path2 / png).c_str());
+	if (!texture) texture = driver->getTexture((textures_path2 / jpg).c_str());
+	if (!texture) texture = default_texture;
+}
+void ImageManager::GetTextureSized_(irr::video::ITexture*& texture, irr::video::ITexture* default_texture, epro::path_string path, uint32_t w, uint32_t h)
+{
+	auto png = path + EPRO_TEXT(".png"), jpg = path + EPRO_TEXT(".jpg");
+	texture = GetTextureFromFile((textures_path / png).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	if (!texture) texture = GetTextureFromFile((textures_path / jpg).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	if (!texture) texture = GetTextureFromFile((textures_path2 / png).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	if (!texture) texture = GetTextureFromFile((textures_path2 / jpg).c_str(), mainGame->Scale(w), mainGame->Scale(h));
+	if (!texture) texture = default_texture;
+}
 
-#define X(x) (textures_path / EPRO_TEXT(x)).c_str()
-#define GET(obj,fun1,fun2) obj=fun1; if(!obj) obj=fun2;
-#define GTFF(path,ext,w,h) GetTextureFromFile(X(path ext), mainGame->Scale(w), mainGame->Scale(h))
-#define GET_TEXTURE_SIZED(obj,path,w,h) GET(obj,GTFF(path,".png",w,h),GTFF(path,".jpg",w,h))
-#define GET_TEXTURE(obj,path) GET(obj,driver->getTexture(X(path ".png")),driver->getTexture(X(path ".jpg")))
+
+#define GET_TEXTURE_SIZED(obj,path,w,h) InitTextureSized_(obj,def_##obj,EPRO_TEXT(path),w,h)
+#define GET_TEXTURE(obj,path) InitTexture_(obj,def_##obj,EPRO_TEXT(path))
 #define CHECK_RETURN(what, name) do { if(!what) { throw std::runtime_error("Couldn't load texture: " name); }} while(0)
 ImageManager::ImageManager() {
 	stop_threads = false;
@@ -52,8 +86,8 @@ ImageManager::~ImageManager() {
 }
 bool ImageManager::Initial() {
 	timestamp_id = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-	// TODO: Allow overriding through data_directory
-	textures_path = gGameConfig->sysdata_directory / BASE_PATH;
+	textures_path = gGameConfig->data_directory / BASE_PATH;
+	textures_path2 = gGameConfig->sysdata_directory / BASE_PATH;
 	GET_TEXTURE_SIZED(tCover[0], "cover", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
 	CHECK_RETURN(tCover[0], "cover");
 	GET_TEXTURE_SIZED(tCover[1], "cover2", CARD_IMG_WIDTH, CARD_IMG_HEIGHT);
@@ -154,21 +188,10 @@ bool ImageManager::Initial() {
 	return true;
 }
 
-#undef GET
 #undef GET_TEXTURE
 #undef GET_TEXTURE_SIZED
-#define GET(to_set,fun1,fun2,fallback) do  {\
-	irr::video::ITexture* tmp = fun1;\
-	if(!tmp)\
-		tmp = fun2;\
-	if(!tmp)\
-		tmp = fallback;\
-	if(to_set != fallback)\
-		driver->removeTexture(to_set);\
-	to_set = tmp;\
-} while(0)
-#define GET_TEXTURE_SIZED(obj,path,w,h) GET(obj,GTFF(path,".png",w,h),GTFF(path,".jpg",w,h),def_##obj)
-#define GET_TEXTURE(obj,path) GET(obj,driver->getTexture(X(path ".png")),driver->getTexture(X(path ".jpg")),def_##obj)
+#define GET_TEXTURE_SIZED(obj,path,w,h) GetTextureSized_(obj,def_##obj,EPRO_TEXT(path),w,h)
+#define GET_TEXTURE(obj,path) GetTexture_(obj,def_##obj,EPRO_TEXT(path))
 void ImageManager::ChangeTextures(epro::path_stringview _path) {
 	if(_path == textures_path)
 		return;
@@ -220,7 +243,7 @@ void ImageManager::ChangeTextures(epro::path_stringview _path) {
 	RefreshCovers();
 }
 void ImageManager::ResetTextures() {
-	ChangeTextures(BASE_PATH);
+	ChangeTextures(gGameConfig->data_directory / BASE_PATH);
 }
 void ImageManager::SetDevice(irr::IrrlichtDevice* dev) {
 	device = dev;
@@ -256,7 +279,6 @@ void ImageManager::ClearTexture(bool resize) {
 }
 #undef GET_TEXTURE
 #undef GET_TEXTURE_SIZED
-#undef X
 void ImageManager::RefreshCachedTextures() {
 	auto LoadTexture = [this](int index, texture_map& dest, auto& size, imgType type) {
 		auto& src = loaded_pics[index];
@@ -318,44 +340,18 @@ void ImageManager::ClearFutureObjects() {
 }
 void ImageManager::RefreshCovers() {
 	irr::video::ITexture* tmp_cover = nullptr;
-#undef GET
-#define GET(obj,fun1,fun2) do {obj=fun1; if(!obj) obj=fun2;} while(0)
-#define X(x) BASE_PATH x
-#define GET_TEXTURE_SIZED(obj,path) do {GET(tmp_cover,GetTextureFromFile(X( path".png"),sizes[1].first,sizes[1].second),GetTextureFromFile(X( path".jpg"),sizes[1].first,sizes[1].second));\
-										if(tmp_cover) {\
-											driver->removeTexture(obj); \
-											obj = tmp_cover;\
-										}} while(0)
+#define GET_TEXTURE_SIZED(obj,path) do {                                \
+		GetTextureSized_(tmp_cover, nullptr, EPRO_TEXT(path),	\
+				 sizes[1].first,sizes[1].second);	\
+		if(tmp_cover) {						\
+			driver->removeTexture(obj);			\
+			obj = tmp_cover;				\
+		}} while (0)
 	GET_TEXTURE_SIZED(tCover[0], "cover");
 	tCover[1] = nullptr;
 	GET_TEXTURE_SIZED(tCover[1], "cover2");
-	if(!tCover[1]) {
-		tCover[1] = tCover[0];
-		def_tCover[1] = tCover[1];
-	}
 	GET_TEXTURE_SIZED(tUnknown, "unknown");
-#undef X
-#define X(x) (textures_path + EPRO_TEXT(x)).data()
-	if(textures_path != BASE_PATH) {
-		GET(tmp_cover, GetTextureFromFile(X("cover.png"), sizes[1].first, sizes[1].second), GetTextureFromFile(X("cover.jpg"), sizes[1].first, sizes[1].second));
-		if(tmp_cover){
-			driver->removeTexture(tCover[0]);
-			tCover[0] = tmp_cover;
-		}
-		GET(tmp_cover, GetTextureFromFile(X("cover2.png"), sizes[1].first, sizes[1].second), GetTextureFromFile(X("cover2.jpg"), sizes[1].first, sizes[1].second));
-		if(tmp_cover){
-			driver->removeTexture(tCover[1]);
-			tCover[1] = tmp_cover;
-		}
-		GET(tmp_cover, GetTextureFromFile(X("unknown.png"), sizes[1].first, sizes[1].second), GetTextureFromFile(X("unknown.jpg"), sizes[1].first, sizes[1].second));
-		if(tmp_cover){
-			driver->removeTexture(tUnknown);
-			tUnknown = tmp_cover;
-		}
-	}
 #undef GET_TEXTURE_SIZED
-#undef GET
-#undef GTFF
 }
 void ImageManager::LoadPic() {
 	Utils::SetThreadName("PicLoader");

--- a/gframe/image_manager.h
+++ b/gframe/image_manager.h
@@ -138,11 +138,16 @@ public:
 	A(tCheckBox[3])
 #undef A
 private:
+	void GetTexture_(irr::video::ITexture*& texture, irr::video::ITexture* fallback, epro::path_string path);
+	void GetTextureSized_(irr::video::ITexture*& texture, irr::video::ITexture* fallback, epro::path_string path, uint32_t w, uint32_t h);
+	void InitTexture_(irr::video::ITexture*& texture, irr::video::ITexture*& default_texture, epro::path_string path);
+	void InitTextureSized_(irr::video::ITexture*& texture, irr::video::ITexture*& default_texture, epro::path_string path, uint32_t w, uint32_t h);
 	void ClearFutureObjects();
 	void RefreshCovers();
 	void LoadPic();
 	load_return LoadCardTexture(uint32_t code, imgType type, const std::atomic<irr::s32>& width, const std::atomic<irr::s32>& height, chrono_time timestamp_id, const std::atomic<chrono_time>& source_timestamp_id);
 	epro::path_string textures_path;
+	epro::path_string textures_path2;
 	std::pair<std::atomic<irr::s32>, std::atomic<irr::s32>> sizes[3];
 	std::atomic<chrono_time> timestamp_id;
 	std::map<epro::path_string, irr::video::ITexture*> g_txrCache;

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -30,6 +30,9 @@ local ygopro_config=function(static_core)
 	if _OPTIONS["environment-paths"] then
 		defines { "YGOPRO_ENVIRONMENT_PATHS" }
 	end
+	if _OPTIONS["xdg-environment"] then
+		defines { "XDG_ENVIRONMENT" }
+	end
 
 	includedirs "../ocgcore"
 	links { "clzma", "freetype", "Irrlicht" }

--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -27,6 +27,10 @@ local ygopro_config=function(static_core)
 	if _OPTIONS["update-url"] then
 		defines { "UPDATE_URL=" .. _OPTIONS["update-url"] }
 	end
+	if _OPTIONS["environment-paths"] then
+		defines { "YGOPRO_ENVIRONMENT_PATHS" }
+	end
+
 	includedirs "../ocgcore"
 	links { "clzma", "freetype", "Irrlicht" }
 	filter "system:macosx"

--- a/gframe/single_mode.cpp
+++ b/gframe/single_mode.cpp
@@ -147,7 +147,7 @@ restart:
 		if(open_file) {
 			script_name = Utils::ToUTF8IfNeeded(open_file_name);
 			if(!mainGame->LoadScript(pduel, script_name)) {
-				script_name = fmt::format("./puzzles/{}" ,script_name);
+				script_name = Utils::ToUTF8IfNeeded(gGameConfig->data_directory / EPRO_TEXT("puzzles") / open_file_name);
 				loaded = mainGame->LoadScript(pduel, script_name);
 			}
 		} else {

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -53,15 +53,15 @@ bool SoundManager::IsUsable() {
 }
 void SoundManager::RefreshBGMList() {
 #ifdef BACKEND
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/"));
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/duel"));
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/menu"));
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/deck"));
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/advantage"));
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/disadvantage"));
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/win"));
-	Utils::MakeDirectory(EPRO_TEXT("./sound/BGM/lose"));
-	for (auto& list : BGMList)
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/"));
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/duel"));
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/menu"));
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/deck"));
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/advantage"));
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/disadvantage"));
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/win"));
+	Utils::MakeDirectory(Utils::ToPathString(working_dir) / EPRO_TEXT("sound/BGM/lose"));
+	for (auto list : BGMList)
 		list.clear();
 	RefreshBGMDir(EPRO_TEXT(""), BGM::DUEL);
 	RefreshBGMDir(EPRO_TEXT("duel"), BGM::DUEL);
@@ -115,7 +115,7 @@ void SoundManager::RefreshSoundsList() {
 }
 void SoundManager::RefreshBGMDir(epro::path_stringview path, BGM scene) {
 #ifdef BACKEND
-	for(auto& file : Utils::FindFiles(fmt::format(EPRO_TEXT("./sound/BGM/{}"), path), mixer->GetSupportedMusicExtensions())) {
+	for(auto& file : Utils::FindFiles(Utils::ToPathString(working_dir) / fmt::format(EPRO_TEXT("sound/BGM/{}"), path), mixer->GetSupportedMusicExtensions())) {
 		auto conv = Utils::ToUTF8IfNeeded(fmt::format(EPRO_TEXT("{}/{}"), path, file));
 		BGMList[BGM::ALL].push_back(conv);
 		BGMList[scene].push_back(std::move(conv));

--- a/gframe/text_types.h
+++ b/gframe/text_types.h
@@ -44,4 +44,18 @@ using stringview = basic_string_view<char>;
 using wstringview = basic_string_view<wchar_t>;
 }
 using namespace nonstd::literals;
+inline epro::path_string operator/(const epro::path_string& base, epro::path_stringview subdir) {
+	if (base.empty() || base == EPRO_TEXT(".")) {
+		epro::path_string path(subdir);
+		return path;
+	}
+	else {
+		epro::path_string path(base);
+		if (base.back() != EPRO_TEXT('/'))
+			path += EPRO_TEXT("/");
+		path += epro::path_string(subdir);
+		return path;
+	}
+}
+
 #endif /* TEXT_TYPES_H_ */

--- a/gframe/utils.cpp
+++ b/gframe/utils.cpp
@@ -363,6 +363,16 @@ namespace ygo {
 		return true;
 	}
 
+	void Utils::PathForeach(epro::path_stringview path, const std::function<void(epro::path_string)>& cb)
+	{
+		// FIXME: should be ';' in WIN32 and WIN64.
+		static const epro::path_char path_sep = EPRO_TEXT(':');
+		std::basic_istringstream<epro::path_char> dirs(path.data());
+		epro::path_string dir;
+		while (std::getline(dirs, dir, path_sep))
+			cb(dir);
+	}
+
 	const epro::path_string& Utils::GetExePath() {
 		static const epro::path_string binarypath = []()->epro::path_string {
 #ifdef _WIN32

--- a/gframe/utils.h
+++ b/gframe/utils.h
@@ -56,6 +56,7 @@ namespace ygo {
 		static irr::io::IFileSystem* filesystem;
 		static irr::IOSOperator* OSOperator;
 		static epro::path_string working_dir;
+		static bool PathIsRelative(epro::path_stringview path);
 		static bool MakeDirectory(epro::path_stringview path);
 #ifdef __linux__
 		static bool FileCopyFD(int source, int destination);

--- a/gframe/utils.h
+++ b/gframe/utils.h
@@ -74,6 +74,7 @@ namespace ygo {
 		static void CreateResourceFolders();
 		static void FindFiles(epro::path_stringview path, const std::function<void(epro::path_stringview, bool)>& cb);
 		static std::vector<epro::path_string> FindFiles(epro::path_stringview path, const std::vector<epro::path_stringview>& extensions, int subdirectorylayers = 0);
+		static void PathForeach(epro::path_stringview path, const std::function<void(epro::path_string)>& cb);
 		/** Returned subfolder names are prefixed by the provided path */
 		static std::vector<epro::path_string> FindSubfolders(epro::path_stringview path, int subdirectorylayers = 1, bool addparentpath = true);
 		static std::vector<int> FindFiles(irr::io::IFileArchive* archive, epro::path_stringview path, const std::vector<epro::path_stringview>& extensions, int subdirectorylayers = 0);

--- a/gframe/utils_gui.cpp
+++ b/gframe/utils_gui.cpp
@@ -210,7 +210,7 @@ bool GUIUtils::TakeScreenshot(irr::IrrlichtDevice* device) {
 	if(!image)
 		return false;
 	const auto now = std::time(nullptr);
-	const auto filename = fmt::format(EPRO_TEXT("screenshots/EDOPro {:%Y-%m-%d %H-%M-%S}.png"), *std::localtime(&now));
+	const auto filename = gGameConfig->data_directory / fmt::format(EPRO_TEXT("screenshots/EDOPro {:%Y-%m-%d %H-%M-%S}.png"), *std::localtime(&now));
 	auto written = driver->writeImageToFile(image, { filename.data(), static_cast<irr::u32>(filename.size()) });
 	if(!written)
 		device->getLogger()->log(L"Failed to take screenshot.", irr::ELL_WARNING);
@@ -356,7 +356,7 @@ void GUIUtils::ShowErrorWindow(epro::stringview context, epro::stringview messag
 		nullptr, //icon url, use default, you can change it depending message_type flags
 		nullptr, //not used
 		nullptr, //localization of strings
-		header_ref, //header text 
+		header_ref, //header text
 		message_ref, //message text
 		nullptr, //default "ok" text in button
 		nullptr, //alternate button title

--- a/premake5.lua
+++ b/premake5.lua
@@ -60,6 +60,10 @@ newoption {
 	value = "url",
 	description = "API endpoint to check for updates from"
 }
+newoption {
+	trigger = "environment-paths",
+	description = "Read databases, scripts and images from YGOPRO_*_PATH"
+}
 workspace "ygo"
 	location "build"
 	language "C++"

--- a/premake5.lua
+++ b/premake5.lua
@@ -64,6 +64,11 @@ newoption {
 	trigger = "environment-paths",
 	description = "Read databases, scripts and images from YGOPRO_*_PATH"
 }
+newoption
+{
+	trigger = "xdg-environment",
+	description = "Use XDG config, data and cache directories."
+}
 workspace "ygo"
 	location "build"
 	language "C++"


### PR DESCRIPTION
This is a cleaner version of [guix-ygopro/edopro-respect-YGOPRO_-_PATH.patch](https://github.com/LordYuuma/guix-ygopro/blob/master/ygopro/patches/edopro-respect-YGOPRO_-_PATH.patch).  If enabled, databases and LFLists will be loaded from `YGOPRO_DATA_PATH`, scripts from `YGOPRO_SCRIPT_PATH`, and card/field/cover images from `YGOPRO_IMAGE_PATH` instead of the current working directory.  To enable, pass `--environment-paths` to premake5.