### PR TITLE
Fixed mute spectator config setting being read as mute opponent setting

### DIFF
--- a/gframe/game_config.cpp
+++ b/gframe/game_config.cpp
@@ -131,7 +131,7 @@ bool GameConfig::Load(const path_char* filename)
 			else if (type == "mute_opponent")
 				chkIgnore1 = !!std::stoi(str);
 			else if (type == "mute_spectators")
-				chkIgnore1 = !!std::stoi(str);
+				chkIgnore2 = !!std::stoi(str);
 			else if (type == "hide_setname")
 				chkHideSetname = !!std::stoi(str);
 			else if (type == "hide_hint_button")


### PR DESCRIPTION
Pull request to fix Issue #143. 
(This is actually my first pull request ever, so I hope I did everything right here!) 