### PR TITLE
sound_manager: Allow configuration of loop parameter.

### DIFF
--- a/gframe/game_config.cpp
+++ b/gframe/game_config.cpp
@@ -165,6 +165,8 @@ bool GameConfig::Load(const path_char* filename)
 				ctrlClickIsRMB = !!std::stoi(str);
 			else if (type == "enable_music")
 				enablemusic = !!std::stoi(str);
+			else if (type == "loop_music")
+				loopmusic = !!std::stoi(str);
 			else if (type == "enable_sound")
 				enablesound = !!std::stoi(str);
 			else if (type == "music_volume")
@@ -263,6 +265,7 @@ bool GameConfig::Save(const path_char* filename)
 	conf_file << "scale_background = "   << scale_background << "\n";
 	conf_file << "accurate_bg_resize = " << accurate_bg_resize << "\n";
 	conf_file << "enable_music = "       << enablemusic << "\n";
+	conf_file << "loop_music = "         << loopmusic << "\n";
 	conf_file << "enable_sound = "       << enablesound << "\n";
 	conf_file << "music_volume = "       << musicVolume << "\n";
 	conf_file << "sound_volume = "       << soundVolume << "\n";

--- a/gframe/game_config.h
+++ b/gframe/game_config.h
@@ -88,6 +88,7 @@ struct GameConfig
 	bool ctrlClickIsRMB = false;
 #endif
 	bool enablemusic = false;
+	bool loopmusic = false;
 	bool discordIntegration = true;
 	bool enablesound = true;
 	bool saveHandTest = true;

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -2,6 +2,7 @@
 #include "sound_manager.h"
 #include "utils.h"
 #include "config.h"
+#include "game_config.h"
 #if defined(YGOPRO_USE_IRRKLANG)
 #include "sound_irrklang.h"
 #define BACKEND SoundIrrklang
@@ -136,7 +137,7 @@ void SoundManager::PlayBGM(BGM scene) {
 		bgm_scene = scene;
 		int bgm = (std::uniform_int_distribution<>(0, count - 1))(rnd);
 		std::string BGMName = working_dir + "/./sound/BGM/" + list[bgm];
-		mixer->PlayMusic(BGMName, true);
+		mixer->PlayMusic(BGMName, gGameConfig->loopmusic);
 	}
 #endif
 }


### PR DESCRIPTION
This patch adds a new loop_music field to the configuration (default false), which must be set for music to loop.  If unset, sound_manager will choose a new BGM at random once the backend stops playing.