### PR TITLE
sound: add SFML backend

### DIFF
--- a/gframe/premake5.lua
+++ b/gframe/premake5.lua
@@ -48,6 +48,11 @@ local ygopro_config=function(static_core)
 			filter "system:macosx"
 				links { "iconv", "CoreAudio.framework", "AudioToolbox.framework", "CoreVideo.framework", "ForceFeedback.framework", "Carbon.framework" }
 		end
+		if _OPTIONS["sound"]=="sfml" then
+			defines "YGOPRO_USE_SFML"
+                        files "sound_sfml.*"
+                        links { "sfml-audio", "sfml-system" }
+		end
 	end
 
 	filter "system:windows"

--- a/gframe/sound_manager.cpp
+++ b/gframe/sound_manager.cpp
@@ -8,6 +8,9 @@
 #elif defined(YGOPRO_USE_SDL_MIXER)
 #include "sound_sdlmixer.h"
 #define BACKEND SoundMixer
+#elif defined(YGOPRO_USE_SFML)
+#include "sound_sfml.h"
+#define BACKEND SoundSFML
 #endif
 
 namespace ygo {

--- a/gframe/sound_sfml.cpp
+++ b/gframe/sound_sfml.cpp
@@ -1,0 +1,97 @@
+#include "sound_sfml.h"
+#include <SFML/Audio.hpp>
+#include <iostream>
+
+SoundSFML::SoundSFML() = default;
+SoundSFML::~SoundSFML() = default;
+
+void SoundSFML::SetSoundVolume(double volume)
+{
+	sound_volume = volume * 100;
+	for (auto& sound: sounds)
+		sound->setVolume(sound_volume);
+}
+
+void SoundSFML::SetMusicVolume(double volume)
+{
+	music_volume = volume * 100;
+	if (music)
+		music->setVolume(music_volume);
+}
+
+bool SoundSFML::PlayMusic(const std::string& name, bool loop)
+{
+	std::unique_ptr<sf::Music> new_music(new sf::Music);
+	if (!new_music)
+		return false;
+	/* supported formats are WAV(PCM), Vorbis and FLAC, but no MP3 */
+	bool can_play = new_music->openFromFile(name);
+	new_music->setVolume(music_volume);
+	new_music->setLoop(loop);
+	if (music)
+		music->stop();
+	music.swap(new_music);
+	if (can_play) {
+		music->play();
+		return true;
+	}
+	else
+		return false;
+}
+const sf::SoundBuffer& SoundSFML::LookupSound(const std::string& name)
+{
+	auto& buf = buffers[name];
+	if (!buf) {
+		std::unique_ptr<sf::SoundBuffer> new_buf(new sf::SoundBuffer);
+		new_buf->loadFromFile(name);
+		buf.swap(new_buf);
+	}
+	return *buf;
+}
+
+bool SoundSFML::PlaySound(const std::string& name)
+{
+	auto& buf = LookupSound(name);
+	if (buf.getSampleCount() == 0) return false;
+	auto sound = new sf::Sound(buf);
+	if (!sound) return false;
+	sound->setVolume(sound_volume);
+	sound->play();
+	sounds.emplace_back(sound);
+	return true;
+}
+
+void SoundSFML::StopSounds()
+{
+	for (auto it = sounds.begin(); it != sounds.end(); it = sounds.erase(it))
+		(*it)->stop();
+	buffers.clear();
+}
+
+void SoundSFML::StopMusic()
+{
+	if (music)
+		music->stop();
+}
+
+void SoundSFML::PauseMusic(bool pause)
+{
+	if (!music) return;
+	if (pause) music->pause();
+	else music->play();
+}
+
+bool SoundSFML::MusicPlaying()
+{
+	return !!music && music->getStatus() == sf::SoundSource::Status::Playing;
+}
+
+void SoundSFML::Tick()
+{
+	for (auto it = sounds.begin(); it != sounds.end();) {
+		if (!(*it)->getStatus() == sf::SoundSource::Status::Playing)
+			it = sounds.erase(it);
+		else
+			it++;
+	}
+}

--- a/gframe/sound_sfml.h
+++ b/gframe/sound_sfml.h
@@ -1,0 +1,33 @@
+#include "sound_backend.h"
+#include <vector>
+#include <memory>
+#include <map>
+#include <string>
+
+namespace sf
+{
+	class Music;
+	class Sound;
+	class SoundBuffer;
+}
+
+class SoundSFML : public SoundBackend {
+public:
+	SoundSFML();
+	~SoundSFML();
+	void SetSoundVolume(double volume);
+	void SetMusicVolume(double volume);
+	bool PlayMusic(const std::string& name, bool loop);
+	bool PlaySound(const std::string& name);
+	void StopSounds();
+	void StopMusic();
+	void PauseMusic(bool pause);
+	bool MusicPlaying();
+	void Tick();
+private:
+	std::unique_ptr<sf::Music> music;
+	std::vector<std::unique_ptr<sf::Sound>> sounds;
+	float music_volume, sound_volume;
+	std::map<std::string,std::unique_ptr<sf::SoundBuffer>> buffers;
+	const sf::SoundBuffer& LookupSound(const std::string& name);
+};

--- a/premake5.lua
+++ b/premake5.lua
@@ -8,7 +8,8 @@ newoption {
 	description = "Choose sound backend",
 	allowed = {
 		{ "irrklang",  "irrklang" },
-		{ "sdl-mixer",  "SDL2-mixer" }
+		{ "sdl-mixer",  "SDL2-mixer" },
+		{ "sfml",  "SFML" }
 	}
 }
 newoption {


### PR DESCRIPTION
This patch adds an audio backend using [SFML](https://www.sfml-dev.org/).