### PR TITLE
Fix broken extension when renaming replay

### DIFF
--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -587,7 +587,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					auto extension = Utils::GetFileExtension(oldname, false);
 					auto newname = Utils::ToPathString(mainGame->ebRSName->getText());
 					if (Utils::GetFileExtension(newname, false) != extension)
-						newname += L"." + extension;
+						newname.append(1, EPRO_TEXT('.')).append(extension);
 					if(Replay::RenameReplay(oldname, oldpath + newname))
 						mainGame->lstReplayList->refreshList();
 					else

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -587,7 +587,7 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					auto extension = Utils::GetFileExtension(oldname, false);
 					auto newname = Utils::ToPathString(mainGame->ebRSName->getText());
 					if (Utils::GetFileExtension(newname, false) != extension)
-						newname += extension;
+						newname += L"." + extension;
 					if(Replay::RenameReplay(oldname, oldpath + newname))
 						mainGame->lstReplayList->refreshList();
 					else


### PR DESCRIPTION
Before, the renamed replay will be saved as <name>yrpX instead of <name>.yrpX .