### PR TITLE
Maintain aspect ratio of currently displayed card no matter what dimensions the window has

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -3169,6 +3169,24 @@ void Game::OnResize() {
 	wBtnSettings->setRelativePosition(ResizeWin(0, 610, 30, 640));
 	SetCentered(wCommitsLog);
 	SetCentered(updateWindow);
+
+	auto wCardImgResizedBounds = ResizeWithAspectRatio(
+		1,
+		1,
+		1 + CARD_IMG_WRAPPER_WIDTH,
+		1 + CARD_IMG_WRAPPER_HEIGHT,
+		CARD_IMG_WRAPPER_ASPECT_RATIO,
+		false
+	);
+
+	wCardImg->setRelativePosition(Scale(wCardImgResizedBounds));
+	imgCard->setRelativePosition(Scale(irr::core::recti(
+		CARD_IMG_WRAPPER_H_PADDING * window_scale.X,
+		CARD_IMG_WRAPPER_V_PADDING * window_scale.Y,
+		wCardImgResizedBounds.getWidth() - CARD_IMG_WRAPPER_H_PADDING * window_scale.X,
+		wCardImgResizedBounds.getHeight() - CARD_IMG_WRAPPER_V_PADDING * window_scale.Y
+	)));
+
 	wDeckEdit->setRelativePosition(Resize(309, 8, 605, 130));
 	cbDBLFList->setRelativePosition(Resize(80, 5, 220, 30));
 	cbDBDecks->setRelativePosition(Resize(80, 35, 220, 60));
@@ -3256,23 +3274,6 @@ void Game::OnResize() {
 	wANRace->setRelativePosition(ResizeWin(480, 200, 850, 410));
 	wFileSave->setRelativePosition(ResizeWin(510, 200, 820, 320));
 	stHintMsg->setRelativePosition(ResizeWin(500, 60, 820, 90));
-
-	auto wCardImgResizedBounds = ResizeWithAspectRatio(
-		1,
-		1,
-		1 + CARD_IMG_WRAPPER_WIDTH,
-		1 + CARD_IMG_WRAPPER_HEIGHT,
-		CARD_IMG_WRAPPER_ASPECT_RATIO,
-		false
-	);
-
-	wCardImg->setRelativePosition(Scale(wCardImgResizedBounds));
-	imgCard->setRelativePosition(Scale(irr::core::recti(
-		CARD_IMG_WRAPPER_H_PADDING * window_scale.X,
-		CARD_IMG_WRAPPER_V_PADDING * window_scale.Y,
-		wCardImgResizedBounds.getWidth() - CARD_IMG_WRAPPER_H_PADDING * window_scale.X,
-		wCardImgResizedBounds.getHeight() - CARD_IMG_WRAPPER_V_PADDING * window_scale.Y
-	)));
 
 	wInfos->setRelativePosition(Resize(1, 275, (infosExpanded == 1) ? 1023 : 301, 639));
 	for(auto& window : repoInfoGui) {

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -3211,7 +3211,7 @@ void Game::OnResize() {
 	btnHandTestSettings->setRelativePosition(Resize(rightOfWCardImgX, 140, 295, 180));
 	btnYdkeManage->setRelativePosition(Resize(rightOfWCardImgX, 190, 295, 230));
 	SetCentered(wYdkeManage, false);
-	stHandTestSettings->setRelativePosition(Resize(0, 0, 90, 40));
+	stHandTestSettings->setRelativePosition(Resize(0, 0, 295 - rightOfWCardImgX, 40));
 	SetCentered(wHandTest, false);
 
 	wSort->setRelativePosition(Resize(930, 132, 1020, 156));

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -3181,10 +3181,10 @@ void Game::OnResize() {
 
 	wCardImg->setRelativePosition(Scale(wCardImgResizedBounds));
 	imgCard->setRelativePosition(Scale(irr::core::recti(
-		CARD_IMG_WRAPPER_H_PADDING * window_scale.X,
-		CARD_IMG_WRAPPER_V_PADDING * window_scale.Y,
-		wCardImgResizedBounds.getWidth() - CARD_IMG_WRAPPER_H_PADDING * window_scale.X,
-		wCardImgResizedBounds.getHeight() - CARD_IMG_WRAPPER_V_PADDING * window_scale.Y
+		CARD_IMG_WRAPPER_H_PADDING,
+		CARD_IMG_WRAPPER_V_PADDING,
+		wCardImgResizedBounds.getWidth() - CARD_IMG_WRAPPER_H_PADDING,
+		wCardImgResizedBounds.getHeight() - CARD_IMG_WRAPPER_V_PADDING
 	)));
 
 	// This points coordinates are the unresized and unscaled lower right corner of wCardImg

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -508,10 +508,15 @@ bool Game::Initialize() {
 	btnHostPrepCancel = env->addButton(Scale(350, 280, 460, 305), wHostPrepare, BUTTON_HP_CANCEL, gDataManager->GetSysString(1210).data());
 	defaultStrings.emplace_back(btnHostPrepCancel, 1210);
 	//img
-	wCardImg = env->addStaticText(L"", Scale(1, 1, 1 + CARD_IMG_WIDTH + 20, 1 + CARD_IMG_HEIGHT + 18), true, false, 0, -1, true);
+	wCardImg = env->addStaticText(L"", Scale(1, 1, 1 + CARD_IMG_WRAPPER_WIDTH, 1 + CARD_IMG_WRAPPER_HEIGHT), true, false, 0, -1, true);
 	wCardImg->setBackgroundColor(skin::CARDINFO_IMAGE_BACKGROUND_VAL);
 	wCardImg->setVisible(false);
-	imgCard = env->addImage(Scale(10, 9, 10 + CARD_IMG_WIDTH, 9 + CARD_IMG_HEIGHT), wCardImg);
+	imgCard = env->addImage(Scale(
+		CARD_IMG_WRAPPER_H_PADDING,
+		CARD_IMG_WRAPPER_V_PADDING,
+		CARD_IMG_WRAPPER_WIDTH - CARD_IMG_WRAPPER_H_PADDING,
+		CARD_IMG_WRAPPER_HEIGHT - CARD_IMG_WRAPPER_V_PADDING
+	), wCardImg);
 	imgCard->setImage(imageManager.tCover[0]);
 	imgCard->setScaleImage(true);
 	imgCard->setUseAlphaChannel(true);
@@ -3252,8 +3257,13 @@ void Game::OnResize() {
 	wFileSave->setRelativePosition(ResizeWin(510, 200, 820, 320));
 	stHintMsg->setRelativePosition(ResizeWin(500, 60, 820, 90));
 
-	wCardImg->setRelativePosition(Resize(1, 1, 1 + CARD_IMG_WIDTH + 20, 1 + CARD_IMG_HEIGHT + 18));
-	imgCard->setRelativePosition(Resize(10, 9, 10 + CARD_IMG_WIDTH, 9 + CARD_IMG_HEIGHT));
+	wCardImg->setRelativePosition(Resize(1, 1, 1 + CARD_IMG_WRAPPER_WIDTH, 1 + CARD_IMG_WRAPPER_HEIGHT));
+	imgCard->setRelativePosition(Resize(
+		CARD_IMG_WRAPPER_H_PADDING,
+		CARD_IMG_WRAPPER_V_PADDING,
+		CARD_IMG_WRAPPER_WIDTH - CARD_IMG_WRAPPER_H_PADDING,
+		CARD_IMG_WRAPPER_HEIGHT - CARD_IMG_WRAPPER_V_PADDING
+	));
 	wInfos->setRelativePosition(Resize(1, 275, (infosExpanded == 1) ? 1023 : 301, 639));
 	for(auto& window : repoInfoGui) {
 		window.second.progress2->setRelativePosition(Scale(5, 20 + 15, (300 - 8) * window_scale.X, 20 + 30));

--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -3187,6 +3187,15 @@ void Game::OnResize() {
 		wCardImgResizedBounds.getHeight() - CARD_IMG_WRAPPER_V_PADDING * window_scale.Y
 	)));
 
+	// This points coordinates are the unresized and unscaled lower right corner of wCardImg
+	// Can be used to place GUI elements right next to or below it
+	irr::s32 wCardImgX2Raw = wCardImgResizedBounds.getWidth() / window_scale.X;
+	irr::s32 wCardImgY2Raw = wCardImgResizedBounds.getHeight() / window_scale.Y;
+
+	// Used for placing various buttons to the right of wCardImg
+	// 15 is roughly the distance between hand test settings and wDeckEdit
+	irr::s32 rightOfWCardImgX = wCardImgX2Raw + 15;
+
 	wDeckEdit->setRelativePosition(Resize(309, 8, 605, 130));
 	cbDBLFList->setRelativePosition(Resize(80, 5, 220, 30));
 	cbDBDecks->setRelativePosition(Resize(80, 35, 220, 60));
@@ -3198,9 +3207,9 @@ void Game::OnResize() {
 	btnSortDeck->setRelativePosition(Resize(80, 95, 145, 120));
 	btnClearDeck->setRelativePosition(Resize(155, 95, 220, 120));
 	btnDeleteDeck->setRelativePosition(Resize(225, 95, 290, 120));
-	btnHandTest->setRelativePosition(Resize(205, 90, 295, 130));
-	btnHandTestSettings->setRelativePosition(Resize(205, 140, 295, 180));
-	btnYdkeManage->setRelativePosition(Resize(205, 190, 295, 230));
+	btnHandTest->setRelativePosition(Resize(rightOfWCardImgX, 90, 295, 130));
+	btnHandTestSettings->setRelativePosition(Resize(rightOfWCardImgX, 140, 295, 180));
+	btnYdkeManage->setRelativePosition(Resize(rightOfWCardImgX, 190, 295, 230));
 	SetCentered(wYdkeManage, false);
 	stHandTestSettings->setRelativePosition(Resize(0, 0, 90, 40));
 	SetCentered(wHandTest, false);
@@ -3316,24 +3325,25 @@ void Game::OnResize() {
 	wChat->setRelativePosition(irr::core::recti(wInfos->getRelativePosition().LowerRightCorner.X + Scale(4), Scale<irr::s32>(615.0f  * window_scale.Y), (window_size.Width - Scale(4 * window_scale.X)), (window_size.Height - Scale(2))));
 
 	if(dInfo.isSingleMode)
-		btnLeaveGame->setRelativePosition(Resize(205, 5, 295, 45));
+		btnLeaveGame->setRelativePosition(Resize(rightOfWCardImgX, 5, 295, 45));
 	else
-		btnLeaveGame->setRelativePosition(Resize(205, 5, 295, 80));
-	btnRestartSingle->setRelativePosition(Resize(205, 50, 295, 90));
-	wReplayControl->setRelativePosition(Resize(205, 143, 295, 273));
-	btnReplayStart->setRelativePosition(Resize(5, 5, 85, 25));
-	btnReplayPause->setRelativePosition(Resize(5, 5, 85, 25));
-	btnReplayStep->setRelativePosition(Resize(5, 55, 85, 75));
-	btnReplayUndo->setRelativePosition(Resize(5, 80, 85, 100));
-	btnReplaySwap->setRelativePosition(Resize(5, 30, 85, 50));
-	btnReplayExit->setRelativePosition(Resize(5, 105, 85, 125));
+		btnLeaveGame->setRelativePosition(Resize(rightOfWCardImgX, 5, 295, 80));
+	btnRestartSingle->setRelativePosition(Resize(rightOfWCardImgX, 50, 295, 90));
+	wReplayControl->setRelativePosition(Resize(rightOfWCardImgX, 143, 295, 273));
+	irr::s32 replayControlWidth = 295 - rightOfWCardImgX;
+	btnReplayStart->setRelativePosition(Resize(5, 5, replayControlWidth - 5, 25));
+	btnReplayPause->setRelativePosition(Resize(5, 5, replayControlWidth - 5, 25));
+	btnReplayStep->setRelativePosition(Resize(5, 55, replayControlWidth - 5, 75));
+	btnReplayUndo->setRelativePosition(Resize(5, 80, replayControlWidth - 5, 100));
+	btnReplaySwap->setRelativePosition(Resize(5, 30, replayControlWidth - 5, 50));
+	btnReplayExit->setRelativePosition(Resize(5, 105, replayControlWidth - 5, 125));
 
 	ResizePhaseButtons();
-	btnSpectatorSwap->setRelativePosition(Resize(205, 100, 295, 135));
-	btnChainAlways->setRelativePosition(Resize(205, 140, 295, 175));
-	btnChainIgnore->setRelativePosition(Resize(205, 100, 295, 135));
-	btnChainWhenAvail->setRelativePosition(Resize(205, 180, 295, 215));
-	btnCancelOrFinish->setRelativePosition(Resize(205, 230, 295, 265));
+	btnSpectatorSwap->setRelativePosition(Resize(rightOfWCardImgX, 100, 295, 135));
+	btnChainAlways->setRelativePosition(Resize(rightOfWCardImgX, 140, 295, 175));
+	btnChainIgnore->setRelativePosition(Resize(rightOfWCardImgX, 100, 295, 135));
+	btnChainWhenAvail->setRelativePosition(Resize(rightOfWCardImgX, 180, 295, 215));
+	btnCancelOrFinish->setRelativePosition(Resize(rightOfWCardImgX, 230, 295, 265));
 
 	auto prev = roomListTable->getSelected();
 

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -748,6 +748,11 @@ irr::core::rect<T> Game::Scale(irr::core::rect<T> rect) {
 
 #define DECK_SEARCH_SCROLL_STEP		100
 
+#define CARD_IMG_WRAPPER_H_PADDING	10
+#define CARD_IMG_WRAPPER_V_PADDING	9
+#define CARD_IMG_WRAPPER_WIDTH 		CARD_IMG_WIDTH + CARD_IMG_WRAPPER_H_PADDING * 2
+#define CARD_IMG_WRAPPER_HEIGHT 	CARD_IMG_HEIGHT + CARD_IMG_WRAPPER_V_PADDING * 2
+
 constexpr float FIELD_X = 4.2f;
 constexpr float FIELD_Y = 8.0f;
 constexpr float FIELD_Z = 7.8f;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -213,6 +213,7 @@ public:
 	irr::core::recti Resize(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y2);
 	irr::core::recti Resize(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y2, irr::s32 dx, irr::s32 dy, irr::s32 dx2, irr::s32 dy2);
 	irr::core::vector2d<irr::s32> Resize(irr::s32 x, irr::s32 y, bool reverse = false);
+	irr::core::recti ResizeWithAspectRatio(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y2, float targetAspectRatio, bool scale);
 	irr::core::recti ResizeElem(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y2, bool scale = true);
 	irr::core::recti ResizePhaseHint(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y2, irr::s32 width);
 	irr::core::recti ResizeWinFromCenter(irr::s32 x, irr::s32 y, irr::s32 x2, irr::s32 y2, irr::s32 xoff = 0, irr::s32 yoff = 0);
@@ -748,10 +749,11 @@ irr::core::rect<T> Game::Scale(irr::core::rect<T> rect) {
 
 #define DECK_SEARCH_SCROLL_STEP		100
 
-#define CARD_IMG_WRAPPER_H_PADDING	10
-#define CARD_IMG_WRAPPER_V_PADDING	9
-#define CARD_IMG_WRAPPER_WIDTH 		CARD_IMG_WIDTH + CARD_IMG_WRAPPER_H_PADDING * 2
-#define CARD_IMG_WRAPPER_HEIGHT 	CARD_IMG_HEIGHT + CARD_IMG_WRAPPER_V_PADDING * 2
+constexpr int 		CARD_IMG_WRAPPER_H_PADDING		= 10;
+constexpr int 		CARD_IMG_WRAPPER_V_PADDING		= 9;
+constexpr int 		CARD_IMG_WRAPPER_WIDTH 			= CARD_IMG_WIDTH + CARD_IMG_WRAPPER_H_PADDING * 2;
+constexpr int 		CARD_IMG_WRAPPER_HEIGHT 		= CARD_IMG_HEIGHT + CARD_IMG_WRAPPER_V_PADDING * 2;
+constexpr float 	CARD_IMG_WRAPPER_ASPECT_RATIO 	= ((float) CARD_IMG_WRAPPER_WIDTH) / ((float) CARD_IMG_WRAPPER_HEIGHT);
 
 constexpr float FIELD_X = 4.2f;
 constexpr float FIELD_Y = 8.0f;

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -749,8 +749,8 @@ irr::core::rect<T> Game::Scale(irr::core::rect<T> rect) {
 
 #define DECK_SEARCH_SCROLL_STEP		100
 
-constexpr int 		CARD_IMG_WRAPPER_H_PADDING		= 10;
-constexpr int 		CARD_IMG_WRAPPER_V_PADDING		= 9;
+constexpr int 		CARD_IMG_WRAPPER_H_PADDING		= 8;
+constexpr int 		CARD_IMG_WRAPPER_V_PADDING		= 8;
 constexpr int 		CARD_IMG_WRAPPER_WIDTH 			= CARD_IMG_WIDTH + CARD_IMG_WRAPPER_H_PADDING * 2;
 constexpr int 		CARD_IMG_WRAPPER_HEIGHT 		= CARD_IMG_HEIGHT + CARD_IMG_WRAPPER_V_PADDING * 2;
 constexpr float 	CARD_IMG_WRAPPER_ASPECT_RATIO 	= ((float) CARD_IMG_WRAPPER_WIDTH) / ((float) CARD_IMG_WRAPPER_HEIGHT);


### PR DESCRIPTION
Most users play edopro on widescreen monitors under which the currently displayed card appears wide/stretched out. This change attempts to fix that.

Comparisons (top image shows current behaviour, bottom one adjusted behaviour):

Window at ~1080p:
![image](https://user-images.githubusercontent.com/23259102/172464528-6260d97f-5e07-447d-9e61-f53d8aa80432.png)
![image](https://user-images.githubusercontent.com/23259102/172464581-2868235a-f10d-47d6-80c9-87961d7231bb.png)



Window at half of ~1080p:
![image](https://user-images.githubusercontent.com/23259102/172464537-37692ee7-42dd-4b44-96c5-124d287fc65a.png)
![image](https://user-images.githubusercontent.com/23259102/172464600-54d4829d-0bcc-4bd6-be5a-dddc63d968f3.png)


The positions of buttons in deck edit, duels and replays were adjusted.

Known issues:
* Some Exit/Leave/Quit buttons are not sized correctly when the current scene is changes. Resizing the window fixes that.