### PR TITLE
Changed deck plaintext export format

### DIFF
--- a/gframe/deck_manager.cpp
+++ b/gframe/deck_manager.cpp
@@ -475,7 +475,7 @@ const wchar_t* DeckManager::ExportDeckCardNames(Deck deck) {
 				prev = code;
 				count = 1;
 			} else if(prev && code != prev) {
-				res.append(epro::format(L"{} x{}\n", gDataManager->GetName(prev), count));
+				res.append(epro::format(L"{} {}\n", count, gDataManager->GetName(prev)));
 				count = 1;
 				prev = code;
 			} else {
@@ -483,7 +483,7 @@ const wchar_t* DeckManager::ExportDeckCardNames(Deck deck) {
 			}
 		}
 		if(prev)
-			res.append(epro::format(L"{} x{}\n", gDataManager->GetName(prev), count));
+			res.append(epro::format(L"{} {}\n", count, gDataManager->GetName(prev)));
 	};
 	bool prev = false;
 	if(deck.main.size()) {


### PR DESCRIPTION
Change from "Effect Veiler x3" to "3 Effect Veiler".

This makes the exported Decklist compatible with cardmarket, tcgplayer and card traders mass insert into wants lists.
The old format wasn't compatible with either of those.

I also considered "3x Effect Veiler" which increases readability imo but breaks compatibility with tcgplayer.
