### PR TITLE
Add ipv6 support

### DIFF
--- a/gframe/Android/porting_android.cpp
+++ b/gframe/Android/porting_android.cpp
@@ -9,6 +9,7 @@
 #include <irrlicht.h>
 #include <vector>
 #include <unistd.h>
+#include <netinet/in.h>
 #include "../log.h"
 #include "../bufferio.h"
 #include "../sound_manager.h"
@@ -405,29 +406,31 @@ bool transformEvent(const irr::SEvent & event, bool& stopPropagation) {
 	return false;
 }
 
-std::vector<uint32_t> getLocalIP() {
-	std::vector<uint32_t> ret;
+std::vector<epro::Address> getLocalIP() {
+	std::vector<epro::Address> addresses;
 	jmethodID getIP = jnienv->GetMethodID(nativeActivity, "getLocalIpAddresses", JPARAMS()JARRAY(JARRAY(JBYTE)));
 	if(getIP == 0) {
-		assert("porting::getLocalIP unable to find java getLocalIpAddress method" == 0);
+		assert("porting::getLocalIP unable to find java getLocalIpAddresses method" == 0);
 	}
 	jobjectArray ipArray = (jobjectArray)jnienv->CallObjectMethod(app_global->activity->clazz, getIP);
 	int size = jnienv->GetArrayLength(ipArray);
 
 	for(int i = 0; i < size; ++i) {
 		jbyteArray ipBuffer = static_cast<jbyteArray>(jnienv->GetObjectArrayElement(ipArray, i));
-		uint32_t ip;
 		int ipBufferSize = jnienv->GetArrayLength(ipBuffer);
 		(void)ipBufferSize;
 		jbyte* ipJava = jnienv->GetByteArrayElements(ipBuffer, nullptr);
-		memcpy(&ip, ipJava, sizeof(ip));
-		ret.push_back(ip);
+		if(ipBufferSize == 4) {
+			addresses.emplace_back(ipJava, epro::Address::INET);
+		} else {
+			addresses.emplace_back(ipJava, epro::Address::INET6);
+		}
 		jnienv->ReleaseByteArrayElements(ipBuffer, ipJava, JNI_ABORT);
 		jnienv->DeleteLocalRef(ipBuffer);
 	}
 
 	jnienv->DeleteLocalRef(ipArray);
-	return ret;
+	return addresses;
 }
 
 #define JAVAVOIDSTRINGMETHOD(name)\

--- a/gframe/Android/porting_android.h
+++ b/gframe/Android/porting_android.h
@@ -3,8 +3,8 @@
 
 #include <vector>
 #include <string>
-#include <cstdint>
 #include "../text_types.h"
+#include "../address.h"
 #include <IEventReceiver.h> //irr::SEvent
 
 namespace irr {
@@ -23,7 +23,7 @@ bool transformEvent(const irr::SEvent& event, bool& stopPropagation);
 
 void showComboBox(const std::vector<std::string>& parameters, int selected);
 
-std::vector<uint32_t> getLocalIP();
+std::vector<epro::Address> getLocalIP();
 
 void launchWindbot(epro::path_stringview args);
 

--- a/gframe/address.cpp
+++ b/gframe/address.cpp
@@ -1,0 +1,95 @@
+#include <event2/event.h>
+#include "address.h"
+#include "bufferio.h"
+#include "config.h"
+#ifdef EPRO_LINUX_KERNEL
+#include <netinet/in.h>
+#endif
+
+namespace epro {
+
+Address::Address(const char* s) :Address{} {
+	if(evutil_inet_pton(AF_INET, s, buffer) == 1) {
+		family = INET;
+		return;
+	}
+	if(evutil_inet_pton(AF_INET6, s, buffer) == 1) {
+		family = INET6;
+		return;
+	}
+}
+
+Address::Address(const void* address, AF address_family) :Address{} {
+	family = address_family;
+	memcpy(buffer, address, family == INET ? sizeof(in_addr::s_addr) : sizeof(in6_addr::s6_addr));
+}
+
+void Address::setIP4(const uint32_t* ip) {
+	family = INET;
+	memcpy(buffer, ip, sizeof(in_addr::s_addr));
+}
+
+void Address::setIP6(const void* ip) {
+	family = INET6;
+	memcpy(buffer, ip, sizeof(in6_addr::s6_addr));
+}
+
+void Address::toInAddr(in_addr& sin_addr) const {
+	memcpy(&sin_addr.s_addr, buffer, sizeof(in_addr::s_addr));
+}
+
+void Address::toIn6Addr(in6_addr& sin6_addr) const {
+	memcpy(sin6_addr.s6_addr, buffer, sizeof(in6_addr::s6_addr));
+}
+
+template<>
+std::basic_string<char> Address::format() const {
+	if(family == UNK)
+		return "";
+	char ret[50]{};
+	if(evutil_inet_ntop(family == INET ? AF_INET : AF_INET6, buffer, ret, sizeof(ret)) == nullptr)
+		return "";
+	return ret;
+}
+
+template<>
+std::basic_string<wchar_t> Address::format() const {
+	return BufferIO::DecodeUTF8(format<char>());
+}
+
+bool Host::operator==(const Host& other) const {
+	if(address.family != other.address.family)
+		return false;
+	if(port != other.port)
+		return false;
+	if(address.family == address.INET) {
+		return memcmp(address.buffer, other.address.buffer, sizeof(in_addr::s_addr)) == 0;
+	}
+	return memcmp(address.buffer, other.address.buffer, sizeof(in6_addr::s6_addr)) == 0;
+}
+
+Host Host::resolve(epro::stringview address, uint16_t port) {
+	Address resolved_address{ address.data() };
+	if(resolved_address.family == Address::UNK) {
+		evutil_addrinfo hints{};
+		evutil_addrinfo* answer = nullptr;
+		hints.ai_socktype = SOCK_STREAM;
+		hints.ai_protocol = IPPROTO_TCP;
+		hints.ai_flags = EVUTIL_AI_ADDRCONFIG;
+		if(evutil_getaddrinfo(address.data(), fmt::to_string(port).data(), &hints, &answer) != 0)
+			throw std::runtime_error("Host not resolved");
+		if(answer->ai_family == PF_INET) {
+			auto* in_answer = reinterpret_cast<sockaddr_in*>(answer->ai_addr);
+			resolved_address = Address{ &in_answer->sin_addr.s_addr,Address::INET };
+		} else if(answer->ai_family == PF_INET6) {
+			auto* addr_ipv6 = reinterpret_cast<sockaddr_in6*>(answer->ai_addr);
+			resolved_address = Address{ &addr_ipv6->sin6_addr.s6_addr,Address::INET6 };
+		} else {
+			throw std::runtime_error("Host not resolved");
+		}
+		evutil_freeaddrinfo(answer);
+	}
+	return { resolved_address, port };
+}
+
+}

--- a/gframe/address.h
+++ b/gframe/address.h
@@ -52,24 +52,15 @@ template<>
 std::basic_string<wchar_t> Address::format() const;
 }
 
-template<>
-struct fmt::formatter<epro::Address, wchar_t> {
+template<typename T>
+struct fmt::formatter<epro::Address, T> {
 	template<typename ParseContext>
 	constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
 
 	template<typename FormatContext>
 	auto format(const epro::Address& address, FormatContext& ctx) {
-		return fmt::format_to(ctx.out(), L"{}", address.format<wchar_t>());
-	}
-};
-template<>
-struct fmt::formatter<epro::Address, char> {
-	template<typename ParseContext>
-	constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
-
-	template<typename FormatContext>
-	auto format(const epro::Address& address, FormatContext& ctx) {
-		return fmt::format_to(ctx.out(), "{}", address.format<char>());
+		static constexpr auto format_str = CHAR_T_STRINGVIEW(T, "{}");
+		return fmt::format_to(ctx.out(), format_str.data(), address.format<T>());
 	}
 };
 

--- a/gframe/address.h
+++ b/gframe/address.h
@@ -1,0 +1,76 @@
+#ifndef ADDRESS_H
+#define ADDRESS_H
+
+#include <cstdint>
+#include <string>
+#include <fmt/core.h>
+#include "bufferio.h"
+#include "text_types.h"
+
+extern "C" {
+	struct in_addr;
+	struct in6_addr;
+}
+
+namespace epro {
+
+struct Address {
+	friend struct Host;
+private:
+	uint8_t buffer[32]{}; //buffer big enough to store an ipv6
+public:
+	enum AF : uint8_t {
+		UNK,
+		INET,
+		INET6,
+	};
+	Address() : family(UNK) {}
+	explicit Address(const char* s);
+	Address(const void* address, AF family);
+	AF family;
+	void setIP4(const uint32_t* ip);
+	void setIP6(const void* ip);
+	template<typename T>
+	std::basic_string<T> format() const;
+	void toInAddr(in_addr& sin_addr) const;
+	void toIn6Addr(in6_addr& sin6_addr) const;
+};
+
+struct Host {
+	Address address{};
+	uint16_t port{};
+	bool operator==(const Host& other) const;
+	static Host resolve(epro::wstringview address, epro::wstringview port) {
+		return resolve(BufferIO::EncodeUTF8(address), static_cast<uint16_t>(std::stoi({ port.data(), port.size() })));
+	}
+	static Host resolve(epro::stringview address, uint16_t port);
+};
+
+template<>
+std::basic_string<char> Address::format() const;
+template<>
+std::basic_string<wchar_t> Address::format() const;
+}
+
+template<>
+struct fmt::formatter<epro::Address, wchar_t> {
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+
+	template<typename FormatContext>
+	auto format(const epro::Address& address, FormatContext& ctx) {
+		return fmt::format_to(ctx.out(), L"{}", address.format<wchar_t>());
+	}
+};
+template<>
+struct fmt::formatter<epro::Address, char> {
+	template<typename ParseContext>
+	constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+
+	template<typename FormatContext>
+	auto format(const epro::Address& address, FormatContext& ctx) {
+		return fmt::format_to(ctx.out(), "{}", address.format<char>());
+	}
+};
+
+#endif //ADDRESS_H

--- a/gframe/discord_wrapper.cpp
+++ b/gframe/discord_wrapper.cpp
@@ -194,9 +194,7 @@ struct DiscordCallbacks {
 				auto ip = it->get<uint32_t>();
 				host.server_address.setIP4(&ip);
 			} else {
-				host.server_address = epro::Address{ json["addrv6"].get_ref<const std::string&>().data()};
-				if(host.server_address.family == epro::Address::UNK)
-					return;
+				host.server_address = epro::Host::resolve(json["addrv6"].get_ref<const std::string&>().data(), host.server_port).address;
 			}
 			host.pass = BufferIO::DecodeUTF8(json["pass"].get_ref<const std::string&>());
 		} catch(const std::exception& e) {

--- a/gframe/discord_wrapper.h
+++ b/gframe/discord_wrapper.h
@@ -3,13 +3,14 @@
 
 #include <string>
 #include <cstdint>
+#include "address.h"
 
 class DiscordWrapper {
 public:
 	friend struct DiscordCallbacks;
 	struct DiscordSecret {
 		uint32_t game_id;
-		uint32_t server_address;
+		epro::Address server_address;
 		uint16_t server_port;
 		std::wstring pass;
 	};

--- a/gframe/discord_wrapper.h
+++ b/gframe/discord_wrapper.h
@@ -10,8 +10,7 @@ public:
 	friend struct DiscordCallbacks;
 	struct DiscordSecret {
 		uint32_t game_id;
-		epro::Address server_address;
-		uint16_t server_port;
+		epro::Host host;
 		std::wstring pass;
 	};
 	enum PresenceType {

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -4460,13 +4460,15 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void* arg) {
 		if(bc_addr.ss_family == AF_INET) {
 			ipaddr = epro::Address{ &reinterpret_cast<sockaddr_in&>(bc_addr).sin_addr.s_addr, epro::Address::INET };
 		} else if(bc_addr.ss_family == AF_INET6) {
-			auto IsV6AddressV4Mapped = [](const in6_addr& in6_addr) {
-				return in6_addr.s6_addr[0] == 0 && in6_addr.s6_addr[5] == 0 &&
-					in6_addr.s6_addr[1] == 0 && in6_addr.s6_addr[6] == 0 &&
-					in6_addr.s6_addr[2] == 0 && in6_addr.s6_addr[7] == 0 &&
-					in6_addr.s6_addr[3] == 0 && in6_addr.s6_addr[8] == 0 &&
-					in6_addr.s6_addr[4] == 0 && in6_addr.s6_addr[9] == 0 &&
-					in6_addr.s6_addr[10] == 0xFF && in6_addr.s6_addr[11] == 0xFF;
+			auto IsV6AddressV4Mapped = [](const in6_addr& addr) {
+				static constexpr in6_addr ipv6Mapped = {
+					{
+						0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00,
+						0x00, 0x00, 0xFF, 0xFF,
+					}
+				};
+				return memcmp(ipv6Mapped.s6_addr, addr.s6_addr, 12) == 0;
 			};
 			const auto& v6addr = reinterpret_cast<sockaddr_in6&>(bc_addr).sin6_addr;
 			if(IsV6AddressV4Mapped(v6addr))

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -4273,11 +4273,11 @@ static std::vector<epro::Address> getAddresses() {
 	if(evutil_getaddrinfo(hname, nullptr, &hints, &res) != 0)
 		return {};
 	for(auto* ptr = res; ptr != nullptr && addresses.size() < 8; ptr = ptr->ai_next) {
-		if(ptr->ai_family == PF_INET) {
+		if(ptr->ai_family == AF_INET) {
 			auto addr_in = reinterpret_cast<sockaddr_in*>(ptr->ai_addr);
 			if(addr_in->sin_addr.s_addr != 0)
 				addresses.emplace_back(&addr_in->sin_addr.s_addr, epro::Address::INET);
-		} else if(ptr->ai_family == PF_INET6) {
+		} else if(ptr->ai_family == AF_INET6) {
 			auto addr_in6 = reinterpret_cast<sockaddr_in6*>(ptr->ai_addr);
 			addresses.emplace_back(addr_in6->sin6_addr.s6_addr, epro::Address::INET6);
 		}

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -110,8 +110,8 @@ bool DuelClient::StartClient(const epro::Address& ip, uint16_t port, uint32_t ga
 		event_add(timeout_event, &timeout);
 	}
 	mainGame->dInfo.secret.game_id = gameid;
-	mainGame->dInfo.secret.server_port = port;
-	mainGame->dInfo.secret.server_address = ip;
+	mainGame->dInfo.secret.host.port = port;
+	mainGame->dInfo.secret.host.address = ip;
 	mainGame->dInfo.isCatchingUp = false;
 	mainGame->dInfo.checkRematch = false;
 	mainGame->frameSignal.SetNoWait(true);

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -4454,6 +4454,8 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void* arg) {
 		ev_socklen_t sz = sizeof(sockaddr_storage);
 		HostPacket packet{};
 		int ret = recvfrom(fd, reinterpret_cast<char*>(&packet), sizeof(packet), 0, (sockaddr*)&bc_addr, &sz);
+		if(ret < static_cast<int>(sizeof(HostPacket)))
+			return;
 		epro::Address ipaddr;
 		if(bc_addr.ss_family == AF_INET) {
 			ipaddr = epro::Address{ &reinterpret_cast<sockaddr_in&>(bc_addr).sin_addr.s_addr, epro::Address::INET };

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -61,50 +61,41 @@ epro::condition_variable DuelClient::cv;
 
 bool DuelClient::is_refreshing = false;
 int DuelClient::match_kill = 0;
-std::vector<HostPacket> DuelClient::hosts;
-std::set<std::pair<uint32_t, uint16_t>> DuelClient::remotes;
+std::vector<epro::Host> DuelClient::hosts;
 event* DuelClient::resp_event = 0;
 
-uint32_t DuelClient::temp_ip = 0;
+epro::Address DuelClient::temp_ip{};
 uint16_t DuelClient::temp_port = 0;
 uint16_t DuelClient::temp_ver = 0;
 bool DuelClient::try_needed = false;
 
-std::pair<uint32_t, uint16_t> DuelClient::ResolveServer(epro::stringview address, uint16_t port) {
-	uint32_t remote_addr = inet_addr(address.data());
-	if (remote_addr == static_cast<uint32_t>(-1)) {
-		evutil_addrinfo hints{};
-		evutil_addrinfo *answer = nullptr;
-		hints.ai_family = AF_INET;
-		hints.ai_socktype = SOCK_STREAM;
-		hints.ai_protocol = IPPROTO_TCP;
-		hints.ai_flags = EVUTIL_AI_ADDRCONFIG;
-		if(evutil_getaddrinfo(address.data(), fmt::to_string(port).data(), &hints, &answer) != 0)
-			throw std::runtime_error("Host not resolved");
-		auto* in_answer = reinterpret_cast<sockaddr_in*>(answer->ai_addr);
-		remote_addr = in_answer->sin_addr.s_addr;
-		evutil_freeaddrinfo(answer);
-	}
-	return { remote_addr, port };
-}
-
-bool DuelClient::StartClient(uint32_t ip, uint16_t port, uint32_t gameid, bool create_game) {
+bool DuelClient::StartClient(const epro::Address& ip, uint16_t port, uint32_t gameid, bool create_game) {
 	if(connect_state)
 		return false;
 	client_base = event_base_new();
 	if(!client_base)
 		return false;
-	sockaddr_in sin;
+	sockaddr_storage sin;
 	memset(&sin, 0, sizeof(sin));
-	sin.sin_family = AF_INET;
-	sin.sin_addr.s_addr = ip;
-	sin.sin_port = htons(port);
+	if(ip.family == ip.INET) {
+		sockaddr_in& sin4 = reinterpret_cast<sockaddr_in&>(sin);
+		sin4.sin_family = AF_INET;
+		ip.toInAddr(sin4.sin_addr);
+		sin4.sin_port = htons(port);
+	} else if(ip.family == ip.INET6) {
+		sockaddr_in6& sin6 = reinterpret_cast<sockaddr_in6&>(sin);
+		sin6.sin6_family = AF_INET6;
+		ip.toIn6Addr(sin6.sin6_addr);
+		sin6.sin6_port = htons(port);
+	} else
+		return false;
 	client_bev = bufferevent_socket_new(client_base, -1, BEV_OPT_CLOSE_ON_FREE | BEV_OPT_THREADSAFE);
 	bufferevent_setcb(client_bev, ClientRead, nullptr, ClientEvent, (void*)create_game);
 	bufferevent_enable(client_bev, EV_READ);
 	temp_ip = ip;
 	temp_port = port;
-	if (bufferevent_socket_connect(client_bev, (sockaddr*)&sin, sizeof(sin)) < 0) {
+	if(bufferevent_socket_connect(client_bev, reinterpret_cast<sockaddr*>(&sin),
+								  ip.family == ip.INET ? sizeof(sockaddr_in) : sizeof(sockaddr_in6)) < 0) {
 		bufferevent_free(client_bev);
 		event_base_free(client_base);
 		client_bev = 0;
@@ -4266,11 +4257,12 @@ void DuelClient::SendResponse() {
 	}
 }
 
-static std::vector<uint32_t> getAddresses() {
-	std::vector<uint32_t> addresses;
+static std::vector<epro::Address> getAddresses() {
 #if EDOPRO_ANDROID
 	return porting::getLocalIP();
-#elif EDOPRO_WINDOWS
+#else
+	std::vector<epro::Address> addresses;
+#if EDOPRO_WINDOWS
 	char hname[256];
 	gethostname(hname, 256);
 	evutil_addrinfo hints;
@@ -4284,7 +4276,10 @@ static std::vector<uint32_t> getAddresses() {
 		if(ptr->ai_family == PF_INET) {
 			auto addr_in = reinterpret_cast<sockaddr_in*>(ptr->ai_addr);
 			if(addr_in->sin_addr.s_addr != 0)
-				addresses.emplace_back(addr_in->sin_addr.s_addr);
+				addresses.emplace_back(&addr_in->sin_addr.s_addr, epro::Address::INET);
+		} else if(ptr->ai_family == PF_INET6) {
+			auto addr_in6 = reinterpret_cast<sockaddr_in6*>(ptr->ai_addr);
+			addresses.emplace_back(addr_in6->sin6_addr.s6_addr, epro::Address::INET6);
 		}
 	}
 	evutil_freeaddrinfo(res);
@@ -4300,12 +4295,16 @@ static std::vector<uint32_t> getAddresses() {
 		if(addr->sa_family == AF_INET) {
 			auto addr_in = reinterpret_cast<sockaddr_in*>(addr);
 			if(addr_in->sin_addr.s_addr != 0)
-				addresses.emplace_back(addr_in->sin_addr.s_addr);
+				addresses.emplace_back(&addr_in->sin_addr.s_addr, epro::Address::INET);
+		} else if (addr->sa_family == AF_INET6) {
+			auto addr_in6 = reinterpret_cast<sockaddr_in6*>(addr);
+			addresses.emplace_back(addr_in6->sin6_addr.s6_addr, epro::Address::INET6);
 		}
 	}
 	freeifaddrs(allInterfaces);
 #endif
 	return addresses;
+#endif
 }
 
 void DuelClient::BeginRefreshHost() {
@@ -4314,7 +4313,6 @@ void DuelClient::BeginRefreshHost() {
 	is_refreshing = true;
 	mainGame->btnLanRefresh->setEnabled(false);
 	mainGame->lstHostList->clear();
-	remotes.clear();
 	hosts.clear();
 	const auto addresses = getAddresses();
 	if(addresses.empty()) {
@@ -4325,52 +4323,113 @@ void DuelClient::BeginRefreshHost() {
 	event_base* broadev = event_base_new();
 	if(!broadev)
 		return;
-	evutil_socket_t reply = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	if(reply == EVUTIL_INVALID_SOCKET) {
-		event_base_free(broadev);
-		return;
-	}
-	sockaddr_in reply_addr;
-	memset(&reply_addr, 0, sizeof(reply_addr));
-	reply_addr.sin_family = AF_INET;
-	reply_addr.sin_port = htons(7921);
-	reply_addr.sin_addr.s_addr = 0;
-	if(bind(reply, reinterpret_cast<sockaddr*>(&reply_addr), sizeof(reply_addr)) == -1) {
-		evutil_closesocket(reply);
+
+	bool hasIpv6 = false;
+
+	auto createAndBindIpv6Socket = [&hasIpv6]() -> evutil_socket_t {
+		evutil_socket_t reply = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+		if(reply == EVUTIL_INVALID_SOCKET)
+			return EVUTIL_INVALID_SOCKET;
+		int off = 0;
+		if(setsockopt(reply, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&off, (ev_socklen_t)sizeof(off)) != 0) {
+			evutil_closesocket(reply);
+			return EVUTIL_INVALID_SOCKET;
+		}
+		sockaddr_in6 reply_addr_v6;
+		memset(&reply_addr_v6, 0, sizeof(reply_addr_v6));
+		reply_addr_v6.sin6_family = AF_INET6;
+		reply_addr_v6.sin6_port = htons(7921);
+		evutil_inet_pton(AF_INET6, "::", &reply_addr_v6.sin6_addr);
+		if(bind(reply, reinterpret_cast<sockaddr*>(&reply_addr_v6), sizeof(reply_addr_v6)) == -1) {
+			evutil_closesocket(reply);
+			return EVUTIL_INVALID_SOCKET;
+		}
+		hasIpv6 = true;
+		return reply;
+	};
+
+	auto createAndBindIpv4Socket = []() -> evutil_socket_t {
+		evutil_socket_t reply = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+		if(reply == EVUTIL_INVALID_SOCKET)
+			return EVUTIL_INVALID_SOCKET;
+		sockaddr_in reply_addr;
+		memset(&reply_addr, 0, sizeof(reply_addr));
+		reply_addr.sin_family = AF_INET;
+		reply_addr.sin_port = htons(7921);
+		reply_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+		if(bind(reply, reinterpret_cast<sockaddr*>(&reply_addr), sizeof(reply_addr)) == -1) {
+			evutil_closesocket(reply);
+			return EVUTIL_INVALID_SOCKET;
+		}
+		return reply;
+	};
+
+	evutil_socket_t reply = createAndBindIpv6Socket();
+	if(reply == EVUTIL_INVALID_SOCKET && (reply = createAndBindIpv4Socket()) == EVUTIL_INVALID_SOCKET) {
 		event_base_free(broadev);
 		mainGame->btnLanRefresh->setEnabled(true);
 		is_refreshing = false;
 		return;
 	}
+
 	timeval timeout = { 3, 0 };
 	resp_event = event_new(broadev, reply, EV_TIMEOUT | EV_READ | EV_PERSIST, BroadcastReply, broadev);
 	event_add(resp_event, &timeout);
 	epro::thread(RefreshThread, broadev).detach();
+
 	//send request
-	sockaddr_in local;
-	local.sin_family = AF_INET;
-	local.sin_port = htons(7922);
-	sockaddr_in sockTo;
-	sockTo.sin_addr.s_addr = htonl(INADDR_BROADCAST);
-	sockTo.sin_family = AF_INET;
-	sockTo.sin_port = htons(7920);
+	sockaddr_in localv4;
+	memset(&localv4, 0, sizeof(localv4));
+	localv4.sin_family = AF_INET;
+	sockaddr_in6 localv6;
+	memset(&localv6, 0, sizeof(localv6));
+	localv6.sin6_family = AF_INET6;
+
+	sockaddr_in sockTov4;
+	memset(&sockTov4, 0, sizeof(sockTov4));
+	sockTov4.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+	sockTov4.sin_family = AF_INET;
+	sockTov4.sin_port = htons(7920);
+	sockaddr_in6 sockTov6;
+	memset(&sockTov6, 0, sizeof(sockTov6));
+	//multicast address
+	evutil_inet_pton(AF_INET6, "FF02::1", &sockTov6.sin6_addr);
+	sockTov6.sin6_family = AF_INET6;
+	sockTov6.sin6_port = htons(7920);
+
 	HostRequest hReq;
 	hReq.identifier = NETWORK_CLIENT_ID;
 	for(const auto& address : addresses) {
-		local.sin_addr.s_addr = address;
-		evutil_socket_t sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-		if(sSend == EVUTIL_INVALID_SOCKET)
-			continue;
-		int opt = 1;
-		setsockopt(sSend, SOL_SOCKET, SO_BROADCAST, (const char*)&opt,
-				   (ev_socklen_t)sizeof(opt));
-		if(bind(sSend, reinterpret_cast<sockaddr*>(&local), sizeof(local)) == -1) {
+		if(address.family == epro::Address::INET6) {
+			if(!hasIpv6)
+				continue;
+			address.toIn6Addr(localv6.sin6_addr);
+			evutil_socket_t sSend = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+			if(sSend == EVUTIL_INVALID_SOCKET)
+				continue;
+			if(bind(sSend, reinterpret_cast<sockaddr*>(&localv6), sizeof(localv6)) == -1) {
+				evutil_closesocket(sSend);
+				continue;
+			}
+			sendto(sSend, reinterpret_cast<const char*>(&hReq), sizeof(HostRequest), 0,
+				   reinterpret_cast<sockaddr*>(&sockTov6), sizeof(sockTov6));
 			evutil_closesocket(sSend);
-			continue;
+		} else {
+			address.toInAddr(localv4.sin_addr);
+			evutil_socket_t sSend = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+			if(sSend == EVUTIL_INVALID_SOCKET)
+				continue;
+			int on = 1;
+			setsockopt(sSend, SOL_SOCKET, SO_BROADCAST, (const char*)&on,
+					   (ev_socklen_t)sizeof(on));
+			if(bind(sSend, reinterpret_cast<sockaddr*>(&localv4), sizeof(localv4)) == -1) {
+				evutil_closesocket(sSend);
+				continue;
+			}
+			sendto(sSend, reinterpret_cast<const char*>(&hReq), sizeof(HostRequest), 0,
+				   reinterpret_cast<sockaddr*>(&sockTov4), sizeof(sockTov4));
+			evutil_closesocket(sSend);
 		}
-		sendto(sSend, reinterpret_cast<const char*>(&hReq), sizeof(HostRequest), 0,
-			   reinterpret_cast<sockaddr*>(&sockTo), sizeof(sockTo));
-		evutil_closesocket(sSend);
 	}
 }
 int DuelClient::RefreshThread(event_base* broadev) {
@@ -4391,21 +4450,37 @@ void DuelClient::BroadcastReply(evutil_socket_t fd, short events, void* arg) {
 		if(!is_closing)
 			mainGame->btnLanRefresh->setEnabled(true);
 	} else if(events & EV_READ) {
-		sockaddr_in bc_addr;
-		ev_socklen_t sz = sizeof(sockaddr_in);
+		sockaddr_storage bc_addr;
+		ev_socklen_t sz = sizeof(sockaddr_storage);
 		HostPacket packet{};
-		(void)recvfrom(fd, reinterpret_cast<char*>(&packet), sizeof(HostPacket), 0, (sockaddr*)&bc_addr, &sz);
-		uint32_t ipaddr = bc_addr.sin_addr.s_addr;
+		int ret = recvfrom(fd, reinterpret_cast<char*>(&packet), sizeof(packet), 0, (sockaddr*)&bc_addr, &sz);
+		epro::Address ipaddr;
+		if(bc_addr.ss_family == AF_INET) {
+			ipaddr = epro::Address{ &reinterpret_cast<sockaddr_in&>(bc_addr).sin_addr.s_addr, epro::Address::INET };
+		} else if(bc_addr.ss_family == AF_INET6) {
+			auto IsV6AddressV4Mapped = [](const in6_addr& in6_addr) {
+				return in6_addr.s6_addr[0] == 0 && in6_addr.s6_addr[5] == 0 &&
+					in6_addr.s6_addr[1] == 0 && in6_addr.s6_addr[6] == 0 &&
+					in6_addr.s6_addr[2] == 0 && in6_addr.s6_addr[7] == 0 &&
+					in6_addr.s6_addr[3] == 0 && in6_addr.s6_addr[8] == 0 &&
+					in6_addr.s6_addr[4] == 0 && in6_addr.s6_addr[9] == 0 &&
+					in6_addr.s6_addr[10] == 0xFF && in6_addr.s6_addr[11] == 0xFF;
+			};
+			const auto& v6addr = reinterpret_cast<sockaddr_in6&>(bc_addr).sin6_addr;
+			if(IsV6AddressV4Mapped(v6addr))
+				ipaddr = epro::Address{ v6addr.s6_addr + 12, epro::Address::INET };
+			else
+				ipaddr = epro::Address{ v6addr.s6_addr, epro::Address::INET6 };
+		} else
+			return;
 		if(is_closing)
 			return;
 		if(packet.identifier != NETWORK_SERVER_ID)
 			return;
-		const auto remote = std::make_pair(ipaddr, packet.port);
-		if(remotes.find(remote) == remotes.end()) {
+		const auto remote = epro::Host{ ipaddr, packet.port };
+		if(std::find(hosts.begin(), hosts.end(), remote) == hosts.end()) {
 			std::lock_guard<epro::mutex> lock(mainGame->gMutex);
-			remotes.insert(remote);
-			packet.ipaddr = ipaddr;
-			hosts.push_back(packet);
+			hosts.push_back(remote);
 			const auto is_compact_mode = packet.host.handshake != SERVER_HANDSHAKE;
 			int rule = packet.host.duel_rule;
 			auto GetRuleString = [&]()-> std::wstring {

--- a/gframe/duelclient.h
+++ b/gframe/duelclient.h
@@ -20,6 +20,7 @@
 #include "deck_manager.h"
 #include "RNG/mt19937.h"
 #include "replay.h"
+#include "address.h"
 
 namespace ygo {
 
@@ -45,18 +46,14 @@ private:
 	static epro::condition_variable cv;
 public:
 	static RNG::mt19937 rnd;
-	static uint32_t temp_ip;
+	static epro::Address temp_ip;
 	static uint16_t temp_port;
 	static uint16_t temp_ver;
 	static bool try_needed;
 	static bool is_local_host;
 	static std::atomic<bool> answered;
 
-	static std::pair<uint32_t, uint16_t> ResolveServer(epro::stringview address, uint16_t port);
-	static inline std::pair<uint32_t, uint16_t> ResolveServer(epro::wstringview address, epro::wstringview port) {
-		return ResolveServer(BufferIO::EncodeUTF8(address), static_cast<uint16_t>(std::stoi({ port.data(), port.size() })));
-	}
-	static bool StartClient(uint32_t ip, uint16_t port, uint32_t gameid = 0, bool create_game = true);
+	static bool StartClient(const epro::Address& ip, uint16_t port, uint32_t gameid = 0, bool create_game = true);
 	static void ConnectTimeout(evutil_socket_t fd, short events, void* arg);
 	static void StopClient(bool is_exiting = false);
 	static void ClientRead(bufferevent* bev, void* ctx);
@@ -139,9 +136,8 @@ protected:
 	static bool is_refreshing;
 	static int match_kill;
 	static event* resp_event;
-	static std::set<std::pair<uint32_t, uint16_t>> remotes;
 public:
-	static std::vector<HostPacket> hosts;
+	static std::vector<epro::Host> hosts;
 	static void BeginRefreshHost();
 	static int RefreshThread(event_base* broadev);
 	static void BroadcastReply(evutil_socket_t fd, short events, void* arg);

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -26,6 +26,7 @@
 #include <IGUITabControl.h>
 #include <IGUITable.h>
 #include <IGUIWindow.h>
+#include "address.h"
 
 namespace ygo {
 
@@ -194,11 +195,11 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 			}
 			case BUTTON_JOIN_HOST: {
 				try {
-					auto parsed = DuelClient::ResolveServer(mainGame->ebJoinHost->getText(), mainGame->ebJoinPort->getText());
+					const auto parsed = epro::Host::resolve(mainGame->ebJoinHost->getText(), mainGame->ebJoinPort->getText());
 					gGameConfig->lasthost = mainGame->ebJoinHost->getText();
 					gGameConfig->lastport = mainGame->ebJoinPort->getText();
 					mainGame->dInfo.secret.pass = mainGame->ebJoinPass->getText();
-					if(DuelClient::StartClient(parsed.first, parsed.second, 0, false)) {
+					if(DuelClient::StartClient(parsed.address, parsed.port, 0, false)) {
 						mainGame->btnCreateHost->setEnabled(false);
 						mainGame->btnJoinHost->setEnabled(false);
 						mainGame->btnJoinCancel->setEnabled(false);
@@ -270,7 +271,8 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 					mainGame->gBot.Refresh(gGameConfig->filterBot * (mainGame->cbDuelRule->getSelected() + 1), gGameConfig->lastBot);
 					if(!NetServer::StartServer(host_port))
 						break;
-					if(!DuelClient::StartClient(0x100007F /*127.0.0.1 in network byte order*/, host_port)) {
+					const auto ip = 0x100007F; //127.0.0.1 in network byte order
+					if(!DuelClient::StartClient({ &ip, epro::Address::INET }, host_port)) {
 						NetServer::StopServer();
 						break;
 					}
@@ -648,10 +650,9 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				int sel = mainGame->lstHostList->getSelected();
 				if(sel == -1)
 					break;
-				int addr = DuelClient::hosts[sel].ipaddr;
-				int port = DuelClient::hosts[sel].port;
-				mainGame->ebJoinHost->setText(epro::format(L"{}.{}.{}.{}", addr & 0xff, (addr >> 8) & 0xff, (addr >> 16) & 0xff, (addr >> 24) & 0xff).data());
-				mainGame->ebJoinPort->setText(fmt::to_wstring(port).data());
+				const auto& selection = DuelClient::hosts[sel];
+				mainGame->ebJoinHost->setText(fmt::to_wstring(selection.address).data());
+				mainGame->ebJoinPort->setText(fmt::to_wstring(selection.port).data());
 				break;
 			}
 			case LISTBOX_REPLAY_LIST: {
@@ -735,11 +736,11 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 				if(sel == -1)
 					break;
 				try {
-					auto parsed = DuelClient::ResolveServer(mainGame->ebJoinHost->getText(), mainGame->ebJoinPort->getText());
+					const auto parsed = epro::Host::resolve(mainGame->ebJoinHost->getText(), mainGame->ebJoinPort->getText());
 					gGameConfig->lasthost = mainGame->ebJoinHost->getText();
 					gGameConfig->lastport = mainGame->ebJoinPort->getText();
 					mainGame->dInfo.secret.pass = mainGame->ebJoinPass->getText();
-					if(DuelClient::StartClient(parsed.first, parsed.second, 0, false)) {
+					if(DuelClient::StartClient(parsed.address, parsed.port, 0, false)) {
 						mainGame->btnCreateHost->setEnabled(false);
 						mainGame->btnJoinHost->setEnabled(false);
 						mainGame->btnJoinCancel->setEnabled(false);

--- a/gframe/netserver.cpp
+++ b/gframe/netserver.cpp
@@ -101,6 +101,9 @@ bool NetServer::StartServer(uint16_t port) {
 	epro::thread(ServerThread).detach();
 	return true;
 }
+#ifndef IPV6_JOIN_GROUP
+#define IPV6_JOIN_GROUP IPV6_ADD_MEMBERSHIP
+#endif
 bool NetServer::StartBroadcast() {
 	if(!net_evbase)
 		return false;
@@ -115,7 +118,7 @@ bool NetServer::StartBroadcast() {
 	struct ipv6_mreq group;
 	group.ipv6mr_interface = 0;
 	evutil_inet_pton(AF_INET6, "FF02::1", &group.ipv6mr_multiaddr);
-	setsockopt(udp, IPPROTO_IPV6, IPV6_ADD_MEMBERSHIP, (const char*)&group, sizeof(group));
+	setsockopt(udp, IPPROTO_IPV6, IPV6_JOIN_GROUP, (const char*)&group, sizeof(group));
 	int off = 0;
 	setsockopt(udp, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&off, (ev_socklen_t)sizeof(off));
 

--- a/gframe/server_lobby.cpp
+++ b/gframe/server_lobby.cpp
@@ -17,6 +17,7 @@
 #include "utils_gui.h"
 #include "custom_skin_enum.h"
 #include "game_config.h"
+#include "address.h"
 
 namespace ygo {
 
@@ -277,17 +278,19 @@ void ServerLobby::JoinServer(bool host) {
 	mainGame->ebNickName->setText(mainGame->ebNickNameOnline->getText());
 	auto selected = mainGame->serverChoice->getSelected();
 	if (selected < 0) return;
-	std::pair<uint32_t, uint16_t> serverinfo;
-	try {
-		const ServerInfo& server = serversVector[selected];
-		serverinfo = DuelClient::ResolveServer(server.address, server.duelport);
-	}
-	catch(const std::exception& e) {
-		ErrorLog("Exception occurred: {}", e.what());
+	const auto serverinfo = [&]() {
+		try {
+			const auto& server = serversVector[selected];
+			return epro::Host::resolve(server.address, server.duelport);
+		} catch(const std::exception& e) {
+			ErrorLog("Exception occurred: {}", e.what());
+			return epro::Host{};
+		}
+	}();
+	if(serverinfo.address.family == epro::Address::UNK)
 		return;
-	}
 	if(host) {
-		if(!DuelClient::StartClient(serverinfo.first, serverinfo.second))
+		if(!DuelClient::StartClient(serverinfo.address, serverinfo.port))
 			return;
 	} else {
 		//client
@@ -306,7 +309,7 @@ void ServerLobby::JoinServer(bool host) {
 			mainGame->dInfo.secret.pass = text;
 		} else
 			mainGame->dInfo.secret.pass.clear();
-		if(!DuelClient::StartClient(serverinfo.first, serverinfo.second, room->id, false))
+		if(!DuelClient::StartClient(serverinfo.address, serverinfo.port, room->id, false))
 			return;
 	}
 }


### PR DESCRIPTION
Make the required changes to support ipv6 for network connections:
- Add an Address class to make the handling of ipv4 and ipv6 as generic as possible in the client
- Make the "client" and "server" work with both ipv4 and ipv6, the server can also accept both type of connections
- Update discord invite secret to support the full ipv6 address range
- Update

LAN broadcast over ipv6 is not 100% working and is pushed as is, but it's a very low priority