### PR TITLE
Add sanity checks to the build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ premake5.exe
 !/irrlicht/premake5.lua
 !/irrlicht/defines.lua
 bundled_font.cpp
+NotoSansJP-Regular.otf

--- a/irrlicht/premake5.lua
+++ b/irrlicht/premake5.lua
@@ -14,5 +14,13 @@ project "Irrlicht"
 	if not _OPTIONS["no-direct3d"] then
 		filter "options:not no-direct3d"
 			defines "IRR_COMPILE_WITH_DX9_DEV_PACK"
-			includedirs(os.getenv("DXSDK_DIR").."/Include")
+			local dxSdkDir = os.getenv("DXSDK_DIR")
+			if not dxSdkDir then
+				error('DirectX SDK not found (DXSDK_DIR envvar not set). See build prerequisites: https://github.com/edo9300/edopro/wiki')
+			end
+			includedirs(dxSdkDir.."/Include")
+	end
+
+	if not (os.isdir('include') and os.isdir('src')) then
+		error('Irrlicht is not installed in the expected location. See dependency installation instructions: https://github.com/edo9300/edopro/wiki')
 	end

--- a/premake5.lua
+++ b/premake5.lua
@@ -62,7 +62,7 @@ newoption {
 }
 newoption {
 	trigger = "no-core",
-	description = "Ignore the ocgcore subproject and only generate the solution for yroprodll"
+	description = "Ignore the ocgcore subproject and only generate the solution for ygoprodll"
 }
 newoption {
 	trigger = "architecture",


### PR DESCRIPTION
Adds some sanity checks in premake.

* `DXSDK_DIR` missing (prerequisites not installed): prints a descriptive error message instead of failing with `attempt to concatenate nil and string`
* Irrlicht missing (dependencies not installed): prints a descriptive error message instead of appearing to succeed, then failing when the solution is built