### PR TITLE
Choose the TCG SEGOC checkbox's default state based on F&L list

### DIFF
--- a/gframe/game.cpp
+++ b/gframe/game.cpp
@@ -2473,6 +2473,15 @@ void Game::RefreshLFLists() {
 	}
 	deckBuilder.filterList = &gdeckManager->_lfList[cbDBLFList->getSelected()];
 	cbFilterBanlist->setSelected(prevFilter);
+	SelectTCGRulesBasedOnLFList();
+}
+void Game::SelectTCGRulesBasedOnLFList() {
+	irr::s32 selected = cbHostLFList->getSelected();
+	if (selected == -1) return;
+	wchar_t const* flListName = cbHostLFList->getItem(selected);
+	size_t n = wcslen(flListName);
+	if (n < 4) return;
+	chkTcgRulings->setChecked(wcsncmp(flListName + (n - 4), L" TCG", 4) == 0);
 }
 void Game::RefreshAiDecks() {
 	gBot.bots.clear();

--- a/gframe/game.h
+++ b/gframe/game.h
@@ -520,6 +520,7 @@ public:
 	bool ApplySkin(const epro::path_string& skin, bool reload = false, bool firstrun = false);
 	void RefreshDeck(irr::gui::IGUIComboBox* cbDeck);
 	void RefreshLFLists();
+	void SelectTCGRulesBasedOnLFList();
 	void RefreshAiDecks();
 	void RefreshReplay();
 	void RefreshSingleplay();

--- a/gframe/menu_handler.cpp
+++ b/gframe/menu_handler.cpp
@@ -953,6 +953,10 @@ bool MenuHandler::OnEvent(const irr::SEvent& event) {
 		}
 		case irr::gui::EGET_COMBO_BOX_CHANGED: {
 			switch (id) {
+			case COMBOBOX_HOST_LFLIST: {
+				mainGame->SelectTCGRulesBasedOnLFList();
+				break;
+			}
 			case COMBOBOX_DUEL_RULE: {
 				auto setDeckSizes = [&](const DeckSizes& size) {
 					mainGame->ebMainMin->setText(epro::to_wstring<int>(size.main.min).data());


### PR DESCRIPTION
See title. If a TCG F&L list is selected, TCG SEGOC defaults to "on". If another F&L list is selected, TCG SEGOC defaults to "off" (the current default).