### PR TITLE
updated custom filter to display cards with more than one scope

### DIFF
--- a/gframe/deck_con.cpp
+++ b/gframe/deck_con.cpp
@@ -1292,7 +1292,7 @@ bool DeckBuilder::CheckCardProperties(const CardDataM& data) {
 					return false;
 				break;
 			case LIMITATION_FILTER_CUSTOM:
-				if(data._data.ot != SCOPE_CUSTOM)
+				if(!(data._data.ot & SCOPE_CUSTOM))
 					return false;
 				break;
 			default:


### PR DESCRIPTION
This is necessary for people who want to make Custom Rush Ritual monsters. In order to do so, they need to label the card as both Custom and Rush. But by doing so, the card doesn't show up in the editor when filtering by Custom cards.